### PR TITLE
Skip some custom file downloads by default

### DIFF
--- a/mastercomfig/cfg/comfig.cfg
+++ b/mastercomfig/cfg/comfig.cfg
@@ -80,6 +80,7 @@ cl_smooth 1 // Smooth out prediction errors
 cl_smoothtime 0.1 // Smooth out view for 0.1 seconds
 // '-- Files --'
 net_maxfilesize 64 // Max out file upload size for extra content
+cl_downloadfilter mapsonly
 //cl_downloadfilter none // Skip downloading items due to crashing on Linux
 // '-- Matchmaking --'
 //tf_mm_custom_ping 100 // The ping tolerance for matchmaking


### PR DESCRIPTION
Let's make it default so that we don't clog our downloads folders with custom sounds, particles, models and other unwanted files.
"nosounds" is also an option here so it's up to you :)