### PR TITLE
added listenserver.cfg and transparent_viewmodels.cfg

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ To get to the `TF2_FOLDER`, right click Team Fortress 2 in your library, click p
 go to the `local files` tab, and then click the `browse local files...` button.
 
 If you already have your own `autoexec.cfg`, copy the contents of `mastercomfig_exec/cfg/autoexec.cfg`
-to the top of your own `autoexec.cfg` and then delete the `mastercomfig_exec` folder.
+to the top of your own `autoexec.cfg` and then delete the `mastercomfig_exec` folder. Do the same with `listenserver.cfg`.
 
 Finally, go to Team Fortress 2 properties again and click the `set launch options...` button.
 Copy and paste `-novid -nojoy -nosteamcontroller -noff -nohltv -softparticlesdefaultoff -reuse -swapcores` into the box and click ok.

--- a/mastercomfig/cfg/addons/transparent_viewmodels.cfg
+++ b/mastercomfig/cfg/addons/transparent_viewmodels.cfg
@@ -5,4 +5,4 @@ mat_hdr_level 0
 mat_antialias 0
 mat_colcorrection_disableentities 1
 mat_colorcorrection 0
-glow_outline_effect_enable 0
+//glow_outline_effect_enable 0 //isn't strictly necessary, but introduces some visual bugs when enabled

--- a/mastercomfig/cfg/addons/transparent_viewmodels.cfg
+++ b/mastercomfig/cfg/addons/transparent_viewmodels.cfg
@@ -1,0 +1,8 @@
+mat_motion_blur_enabled 1
+mat_motion_blur_strength 0
+mat_disable_bloom 1
+mat_hdr_level 0
+mat_antialias 0
+mat_colcorrection_disableentities 1
+mat_colorcorrection 0
+glow_outline_effect_enable 0

--- a/mastercomfig_exec/cfg/autoexec.cfg
+++ b/mastercomfig_exec/cfg/autoexec.cfg
@@ -103,7 +103,7 @@ exec comfig // Main config file
 //exec addons/stripped // Stripped quality addon - Significantly reduces playability in desperation for frames on very, weak hardware
                        // maxperformance preset and igpu addon recommended
 //exec addons/transparent_viewmodels // Enables use of transparent viewmodels
-					   
+					                 // the transparent viewmodel materials require dxlevel90 or higher
 
 // ================
 // '--- Custom ---'

--- a/mastercomfig_exec/cfg/autoexec.cfg
+++ b/mastercomfig_exec/cfg/autoexec.cfg
@@ -102,6 +102,8 @@ exec comfig // Main config file
                    // maxperformance or comp presets recommended
 //exec addons/stripped // Stripped quality addon - Significantly reduces playability in desperation for frames on very, weak hardware
                        // maxperformance preset and igpu addon recommended
+//exec addons/transparent_viewmodels // Enables use of transparent viewmodels
+					   
 
 // ================
 // '--- Custom ---'

--- a/mastercomfig_exec/cfg/listenserver.cfg
+++ b/mastercomfig_exec/cfg/listenserver.cfg
@@ -1,1 +1,12 @@
-host_thread_mode 0
+host_thread_mode 0 // Do not use the threaded frame behavior, since that causes problems on listen servers
+
+// warning system
+incrementvar sv_allow_wait_command -1 2 1
+incrementvar developer -1 2 1
+wait 1500; echo ""
+wait 1500; echo ""
+wait 1500; echo ""
+wait 1500; echo ""
+wait 1500; echo ""
+wait 1500; echo "-> run 'host_thread_mode 1' when on servers again"
+wait 8000; incrementvar developer -1 2 -1; incrementvar sv_allow_wait_command -1 2 -1

--- a/mastercomfig_exec/cfg/listenserver.cfg
+++ b/mastercomfig_exec/cfg/listenserver.cfg
@@ -1,4 +1,4 @@
-host_thread_mode 0 // Do not use the threaded frame behavior, since that causes problems on listen servers
+//host_thread_mode 0 // Do not use the threaded frame behavior, since that causes problems on listen servers
 
 // warning system
 incrementvar sv_allow_wait_command -1 2 1
@@ -7,6 +7,6 @@ wait 1500; echo ""
 wait 1500; echo ""
 wait 1500; echo ""
 wait 1500; echo ""
-wait 1500; echo ""
-wait 1500; echo "-> run 'host_thread_mode 1' when on servers again"
+wait 1500; echo "-> run 'host_thread_mode 0' for listen servers"
+wait 1500; echo "-> run 'host_thread_mode 1' when going on servers again"
 wait 8000; incrementvar developer -1 2 -1; incrementvar sv_allow_wait_command -1 2 -1

--- a/mastercomfig_exec/cfg/listenserver.cfg
+++ b/mastercomfig_exec/cfg/listenserver.cfg
@@ -1,0 +1,1 @@
+host_thread_mode 0


### PR DESCRIPTION
listenserver.cfg automatically sets host_thread_mode so that listen servers function

transparent_viewmodels.cfg is an addon that provides the standard settings for transparent viewmodels