### PR TITLE
Add ability for users to change custom file names

### DIFF
--- a/config/mastercomfig/cfg/comfig.cfg
+++ b/config/mastercomfig/cfg/comfig.cfg
@@ -1808,3 +1808,21 @@ echo " "
 mem_compact // Slightly organize memory on startup
 con_filter_text_out "particle" // filter out unknown particle errors
 alias game_override "cheap_water_override; detail_props_override" // Set game override alias
+
+// ---------------------------------
+// '-- User-Overrideable Aliases --'
+// ---------------------------------
+//
+
+alias class_config_scout        "exec scout_c"
+alias class_config_soldier      "exec soldier_c"
+alias class_config_pyro         "exec pyro_c"
+alias class_config_demoman      "exec demoman_c"
+alias class_config_heavyweapons "exec heavyweapons_c"
+alias class_config_engineer     "exec engineer_c"
+alias class_config_medic        "exec medic_c"
+alias class_config_sniper       "exec sniper_c"
+alias class_config_spy          "exec spy_c"
+
+alias game_overrides_c "exec game_overrides_c"
+alias listenserver_c   "exec listenserver_c"

--- a/config/mastercomfig/cfg/demoman.cfg
+++ b/config/mastercomfig/cfg/demoman.cfg
@@ -1,3 +1,3 @@
 exec game_overrides // Override values set every game
 
-exec demoman_c
+class_config_demoman

--- a/config/mastercomfig/cfg/engineer.cfg
+++ b/config/mastercomfig/cfg/engineer.cfg
@@ -1,3 +1,3 @@
 exec game_overrides // Override values set every game
 
-exec engineer_c
+class_config_engineer

--- a/config/mastercomfig/cfg/game_overrides.cfg
+++ b/config/mastercomfig/cfg/game_overrides.cfg
@@ -1,5 +1,5 @@
 game_override // Run aliased game overrides
-exec game_overrides_c
+game_overrides_c
 
 //soundscape_flush // Flush soundscapes
 //scene_flush // Flush anims (may cause issues and trigger bans with SourceOP)

--- a/config/mastercomfig/cfg/heavyweapons.cfg
+++ b/config/mastercomfig/cfg/heavyweapons.cfg
@@ -1,3 +1,3 @@
 exec game_overrides // Override values set every game
 
-exec heavyweapons_c
+class_config_heavyweapons

--- a/config/mastercomfig/cfg/listenserver.cfg
+++ b/config/mastercomfig/cfg/listenserver.cfg
@@ -6,4 +6,4 @@ incrementvar sv_allow_wait_command -1 2 1;incrementvar developer -1 2 1
 wait 1500; echo "    ******************************************************    "; echo "    ******************************************************    "; echo "    ******************************************************    "; echo "    ******************************************************    "; echo "=> Set host_thread_mode 0 for local servers."; echo "=> Set host_thread_mode 1 once you are done with your local server."
 wait 8000; incrementvar developer -1 2 -1; incrementvar sv_allow_wait_command -1 2 -1
 
-exec listenserver_c
+listenserver_c

--- a/config/mastercomfig/cfg/medic.cfg
+++ b/config/mastercomfig/cfg/medic.cfg
@@ -1,3 +1,3 @@
 exec game_overrides // Override values set every game
 
-exec medic_c
+class_config_medic

--- a/config/mastercomfig/cfg/pyro.cfg
+++ b/config/mastercomfig/cfg/pyro.cfg
@@ -1,3 +1,3 @@
 exec game_overrides // Override values set every game
 
-exec pyro_c
+class_config_pyro

--- a/config/mastercomfig/cfg/scout.cfg
+++ b/config/mastercomfig/cfg/scout.cfg
@@ -1,3 +1,3 @@
 exec game_overrides // Override values set every game
 
-exec scout_c
+class_config_scout

--- a/config/mastercomfig/cfg/sniper.cfg
+++ b/config/mastercomfig/cfg/sniper.cfg
@@ -1,3 +1,3 @@
 exec game_overrides // Override values set every game
 
-exec sniper_c
+class_config_sniper

--- a/config/mastercomfig/cfg/soldier.cfg
+++ b/config/mastercomfig/cfg/soldier.cfg
@@ -1,3 +1,3 @@
 exec game_overrides // Override values set every game
 
-exec soldier_c
+class_config_soldier

--- a/config/mastercomfig/cfg/spy.cfg
+++ b/config/mastercomfig/cfg/spy.cfg
@@ -1,3 +1,3 @@
 exec game_overrides // Override values set every game
 
-exec spy_c
+class_config_spy


### PR DESCRIPTION
Use aliases for class config files instead of hardcoding file names. This way the user can choose their own file names instead of the now hardcoded 'class_c.cfg,' convention. For example this allows the user to avoid file clutter by putting class files in their own directory. As another example the files can be organised by class number instead of alphabetically by using file names like '1_scout.cfg.'