### PR TITLE
"Unknown command block_game_override_once" fix

### DIFF
--- a/config/mastercomfig/cfg/comfig/comfig.cfg
+++ b/config/mastercomfig/cfg/comfig/comfig.cfg
@@ -1593,5 +1593,5 @@ alias restore_config "exec autoexec"
 
 alias game_override_once_c ""
 alias game_override_once "hud_reloadscheme;game_override_once_c;block_game_override_once" // Run HUD reload once in game
-block_game_override_once
 alias block_game_override_once "alias game_override_once echo"
+block_game_override_once


### PR DESCRIPTION
Fix for the "Unknown command block_game_override_once"