### PR TITLE
Some gameplay related cvars changed

### DIFF
--- a/config/mastercomfig/cfg/comfig/comfig.cfg
+++ b/config/mastercomfig/cfg/comfig/comfig.cfg
@@ -112,7 +112,7 @@ alias download_nosounds "cl_downloadfilter nosounds"
 alias download_mapsonly "cl_downloadfilter mapsonly"
 alias download_none "cl_downloadfilter none"
 
-alias download download_mapsonly
+alias download download_all
 
 // -------------------
 // '-- Matchmaking --'
@@ -866,7 +866,7 @@ tf_healthicon_height_offset 10 // Offset of heath icon
 tf_hud_num_building_alert_beeps 2 // Numbers of beeps when an alert pops up on an engie building
 //tf_rd_finale_beep_time 10 // Beep time during robot destruction victory
 tf_hud_show_servertimelimit 1 // Show server map time
-tf_hud_target_id_alpha 100 // Transparency of target ID
+tf_hud_target_id_alpha 255 // Transparency of target ID
 //tf_hud_target_id_disable_floating_health 0 // Show floating health bar
 //tf_hud_target_id_disable_floating_health 1 // Hide floating health bar
 hud_medichealtargetmarker 1 // Shows medic heal target with a small marker
@@ -1107,7 +1107,7 @@ fov_desired 90 // See more of the battlefield
 //tf_use_min_viewmodels 1 // Move viewmodel to cover less of the screen
 //cl_first_person_uses_world_model 0 // Draw viewmodel
 //cl_first_person_uses_world_model 1 // Draw character world model instead of viewmodel
-tf_medieval_thirdperson 1 // Third person view in medieval mode
+tf_medieval_thirdperson 0 // First person view in medieval mode
 //tf_taunt_first_person 1 // First person taunt
 //glow_outline_effect_enable 1 // Enable ally and objective x-rays
 //glow_outline_effect_enable 0 // Disable all x-rays
@@ -1229,13 +1229,13 @@ mod_touchalldata 0 // Skip submodels when async loading. If this is on, async lo
 // -----------------
 // Damage sound played on hit and on kill
 
-//tf_dingalingaling_lasthit 1 // Play killsounds
+tf_dingalingaling_lasthit 1 // Play killsounds
 //tf_dingaling_lasthit_pitchmaxdmg 65 // Pitch for killsound on >=150 damage
 //tf_dingaling_lasthit_pitchmindmg 127 // Pitch for killsound on <=10 damage
 //tf_dingaling_lasthit_volume 0.7 // Killsound volume
 //tf_dingalingaling_last_effect 0 // Which sound to use for the killsound
 //tf_dingaling_lasthit_pitch_override -1 // Pitch for all killsounds, if set
-//tf_dingalingaling 1 // Play hitsounds
+tf_dingalingaling 1 // Play hitsounds
 //tf_dingaling_pitchmaxdmg 65 // Pitch for hitsound on >=150 damage
 //tf_dingaling_pitchmindmg 127 // Pitch for hitsound on <=10 damage
 //tf_dingalingaling_repeat_delay 0 // The delay in seconds before playing the hitsound again

--- a/config/mastercomfig/cfg/comfig/comfig.cfg
+++ b/config/mastercomfig/cfg/comfig/comfig.cfg
@@ -866,7 +866,7 @@ tf_healthicon_height_offset 10 // Offset of heath icon
 tf_hud_num_building_alert_beeps 2 // Numbers of beeps when an alert pops up on an engie building
 //tf_rd_finale_beep_time 10 // Beep time during robot destruction victory
 tf_hud_show_servertimelimit 1 // Show server map time
-tf_hud_target_id_alpha 255 // Transparency of target ID
+tf_hud_target_id_alpha 100 // Transparency of target ID
 //tf_hud_target_id_disable_floating_health 0 // Show floating health bar
 //tf_hud_target_id_disable_floating_health 1 // Hide floating health bar
 hud_medichealtargetmarker 1 // Shows medic heal target with a small marker
@@ -1107,7 +1107,8 @@ fov_desired 90 // See more of the battlefield
 //tf_use_min_viewmodels 1 // Move viewmodel to cover less of the screen
 //cl_first_person_uses_world_model 0 // Draw viewmodel
 //cl_first_person_uses_world_model 1 // Draw character world model instead of viewmodel
-tf_medieval_thirdperson 0 // First person view in medieval mode
+//tf_medieval_thirdperson 0 // First person view in medieval mode
+//tf_medieval_thirdperson 1 // Third person view in medieval mode
 //tf_taunt_first_person 1 // First person taunt
 //glow_outline_effect_enable 1 // Enable ally and objective x-rays
 //glow_outline_effect_enable 0 // Disable all x-rays

--- a/config/mastercomfig/cfg/comfig/comfig.cfg
+++ b/config/mastercomfig/cfg/comfig/comfig.cfg
@@ -112,7 +112,7 @@ alias download_nosounds "cl_downloadfilter nosounds"
 alias download_mapsonly "cl_downloadfilter mapsonly"
 alias download_none "cl_downloadfilter none"
 
-alias download download_all
+alias download download_mapsonly
 
 // -------------------
 // '-- Matchmaking --'


### PR DESCRIPTION
I changed some cvars because, in my opinion, the values that I choosed it's better for the gameplay.

download_all - because some community servers have custom sounds/models, like Freak Fortress 2 servers.

tf_hud_target_id_alpha - value 255 because it's better to see people info when playing (teammates or enemies if you are a Spy).

tf_medieval_thirdperson - value 0 because it's hard to trickstab when playing with the Spy and also when playing as Sniper with the Huntsman.

tf_dingalingaling and tf_dingalingaling_lasthit - value 1 for the two options because it will help newbies in the game.