### PR TITLE
ragdoll_sleepaftertime on ragdolls_medium

### DIFF
--- a/config/mastercomfig/cfg/comfig/comfig.cfg
+++ b/config/mastercomfig/cfg/comfig/comfig.cfg
@@ -657,7 +657,7 @@ alias props_ultra "r_decalstaticprops 1;cl_phys_props_enable 1;cl_phys_props_max
 //ragdoll_sleepaftertime 1 // Wait a reasonable time before sleeping ragdoll physics
 
 alias ragdolls_off "cl_ragdoll_fade_time 0;cl_ragdoll_forcefade 1;cl_ragdoll_physics_enable 0;ragdoll_sleepaftertime 0"
-alias ragdolls_medium "cl_ragdoll_fade_time 5;cl_ragdoll_forcefade 0;cl_ragdoll_physics_enable 1;ragdoll_sleepaftertime 1"
+alias ragdolls_medium "cl_ragdoll_fade_time 5;cl_ragdoll_forcefade 0;cl_ragdoll_physics_enable 1;ragdoll_sleepaftertime 1.5"
 alias ragdolls_high "cl_ragdoll_fade_time 15;cl_ragdoll_forcefade 0;cl_ragdoll_physics_enable 1;ragdoll_sleepaftertime 2.5"
 
 // ---------------


### PR DESCRIPTION
Changing value here, because there's a chance to play a specific death animation on Medic that is more than 1 second to finish (about 1.2 seconds or below). When this animation plays and the ragdoll_sleepaftertime is with the value of 1, the animation freezes in the mid-air. Just putting 0.5 more here to fix that.