### PR TITLE
Spiff up "Troubleshooting" page a little

### DIFF
--- a/docs/next_steps/troubleshoot.md
+++ b/docs/next_steps/troubleshoot.md
@@ -2,20 +2,20 @@
 
 ## Viewmodels are not visible
 
-Put the following in your `user/autoexec.cfg`:
+Add the following to your `user/autoexec.cfg`:
 
 ```c
-viewmodel_fov 54
+viewmodel_fov 70
 r_drawviemodel 1
 ```
 
-Instead of `54` for `viewmodel_fov`, you can use any value you prefer.
+Instead of `70` for `viewmodel_fov`, you can use any value you prefer.
 
 ## Game stutters on join
 
-This is a feature of mastercomfig which fixes the %killername% bug and other HUD bugs.
+To counteract the %killername% bug and other HUD bugs, mastercomfig runs `hud_reloadscheme` on your first life, with the caveat of the game stuttering/freezing when you first join.
 
-You can disable it by putting `alias game_overrides_once` into your `user/autoexec.cfg`.
+You can disable it by adding `alias game_overrides_once` to your `user/autoexec.cfg`, though this is not recommended.
 
 ## TF2 crashes when entering a Competitive Matchmaking match
 
@@ -29,27 +29,23 @@ You will have to exit the game to reset the lock that competitive puts on the ga
 
 ## TF2 exits on startup
 
-Make sure you don't have any infinite loops caused by an `exec autoexec` in your custom configs (like in your `user/autoexec.cfg`).
+Make sure you don't have any infinite loops caused by an `exec autoexec` in your custom configs (like in your `user/autoexec.cfg`). Additionally, make sure your custom configs don't contain `quit`, and that your launch options don't contain `+quit`.
 
-## Animation and/or model mods not working
+## Preloading animation and/or model mods not working
 
-If you are trying to use this sort of mod and preload it to bypass `sv_pure`, people have found async disk loading to be incompatible with preloading, so you'll have to use the Slow I/O addon.
+If you are trying to use this sort of mod and preload it to bypass `sv_pure`, people have found async disk loading to be incompatible with preloading. Install the Slow I/O addon to completely disable async loading, and thus fix this issue.
 
 ## yttrium's viewmodels not preloading
 
-If you use yttrium's viewmodels, the installer adds a preload command to your `autoexec.cfg`. However, since mastercomfig doesn't use your `autoexec.cfg`, you'll have to add this to your `user/autoexec.cfg`:
+If you use yttrium's viewmodels, the installer adds the preload commands to your `autoexec.cfg`. However, since mastercomfig doesn't use your `autoexec.cfg`, you'll have to add this to your `user/autoexec.cfg`:
 
 ```c
 map_background preload_room; wait 10; disconnect
 ```
 
-## Crashing when trying to preload mods
-
-Preloading conflicts with a memory usage optimization in the mastercomfig low memory addon. Set `cl_always_flush_models 0`.
-
 ## TF2 crashing on a custom map
 
-If TF2 is crashing to desktop after a custom map loading / after picking a class on a custom map enter `mat_phong 1` in console. The crashes are caused by lightmapped props and phong must be enabled to allow the map to load properly. All Valve maps except for `rd_asteroid` don't use lightmapped props. More information at [TF2Maps](https://tf2maps.net/threads/guide-prop-lightmaps.24682/).
+If TF2 is crashing to desktop after a custom map loading or after picking a class on a custom map, enter `mat_phong 1` in console. The crashes are caused by lightmapped props and phong must be enabled to allow the map to load properly. All Valve maps except for `rd_asteroid` don't use lightmapped props. More information at [TF2Maps](https://tf2maps.net/threads/guide-prop-lightmaps.24682/).
 
 ## Item panels are taking too long to load
 
@@ -57,12 +53,12 @@ Add `tf_time_loading_item_panels 0.0005` to `user/autoexec.cfg`.
 
 ## Players' sprays are not working even with the module enabled
 
-Players' sprays are treated like a decal in-game. To get sprays to work, you have to least to set the `decals` module to `low` or higher.
+Players' sprays are treated like a decal in-game. To get sprays to work, you have to set the `decals` module to `low` or higher.
 
-## Multiple particle-related errors in console
+## Particle-related errors in console
 
 Ignore these, as these are red herrings that happen in a clean TF2 installation and do not affect FPS.
 
-## Unknown command "gl_*"
+## "Unknown command gl_\*" errors in console
 
-OpenGL-related cvars are only available on Linux and macOS. Therefore, errors of this type appear a few times when using mastercomfig on Windows. These errors are harmless and can be ignored safely.
+mastercomfig sets some OpenGL-related cvars, which are only available on Linux and macOS. Thus, these errors appear a few times when using mastercomfig on Windows. These errors are harmless and can be ignored safely.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -26,7 +26,7 @@ nav:
         - Windows: 'os/windows.md'
         - Linux: 'os/linux.md'
     - Next Steps:
-        - Troubleshoot: 'next_steps/troubleshoot.md'
+        - Troubleshooting: 'next_steps/troubleshoot.md'
         - Update: 'next_steps/update.md'
     - TF2 Documentation:
         - Misconceptions: 'tf2/misconceptions.md'


### PR DESCRIPTION
Also renames the page from "Troubleshoot" to "Troubleshooting".