### PR TITLE
Fix incorrect alias on mm_override.cfg

### DIFF
--- a/config/mastercomfig/cfg/comfig/mm_override.cfg
+++ b/config/mastercomfig/cfg/comfig/mm_override.cfg
@@ -1,4 +1,4 @@
-alias game_override
+alias game_overrides
 
 blink_duration .2
 cl_blobbyshadows 0
@@ -124,6 +124,8 @@ tf_clientsideeye_lookats 1
 tracer_extra 1
 violence_hgibs 1
 violence_hblood 1
+violence_agibs 1
+violence_ablood 1
 plugin_unload 0
 
 echo "Competitive matchmaking settings applied"


### PR DESCRIPTION
The correct alias is `game_overrides` now due to updates.