### PR TITLE
Update comfig.cfg

### DIFF
--- a/config/mastercomfig/cfg/comfig/comfig.cfg
+++ b/config/mastercomfig/cfg/comfig/comfig.cfg
@@ -24,7 +24,7 @@ cl_timeout 60 // Max client timeout
 //hud_escort_interp .2 // Smooth out payload cart progress over slightly less time
 //cl_pred_optimize 1 // Avoid bug with mode 2 that causes client prediction to be used over server data
 
-alias pred_opt_none
+alias pred_opt_none "cl_pred_optimize 0"
 alias pred_opt_base "cl_pred_optimize 1"
 alias pred_opt_full "cl_pred_optimize 2"
 
@@ -104,8 +104,8 @@ alias packet_size packet_size_balanced
 // Rate should be 80% of your stable internet speed in bytes per second
 // (upload or download, whichever is slowest)
 
-//rate 131072 // Rate used for server communication, delays packets based on this value and packet size
-//net_maxcleartime 0.06 // Maximum time in seconds packets can be held for
+//rate 196608 // Rate used for server communication, delays packets based on this value and packet size
+//net_maxcleartime .025 // Maximum time in seconds packets can be held for
 //net_splitpacket_maxrate 80000 // Lower split packet rate to make sure they are transmitted properly
 
 alias bandwidth_restricted "rate 24576;net_maxcleartime .163"
@@ -119,7 +119,7 @@ alias bandwidth_2.5Mbps "rate 327680;net_maxcleartime .012"
 alias bandwidth_3.0Mbps "rate 393216;net_maxcleartime .01"
 alias bandwidth_4.0Mbps "rate 524288;net_maxcleartime .08"
 alias bandwidth_unrestricted "rate 786432;net_maxcleartime .005"
-alias bandwidth_max "rate 1048576;net_maxcleartime 0.004"
+alias bandwidth_max "rate 1048576;net_maxcleartime .004"
 
 alias bandwidth bandwidth_1.5Mbps
 
@@ -1586,8 +1586,6 @@ alias game_overrides_once game_overrides_once_c
 block_game_overrides_once
 
 alias version_comfig "echo mastercomfig version: 8.3.5 | January 26 2020"
-
-clear
 
 echo " "
 echo " "


### PR DESCRIPTION
Do not clean the console by default, it may have some information essential for resolving an error.
The proof of this is that I found an error of a HUD that was not working for me, and when uninstalling the mastercomfig, I could see the error generated on the console, which I could not see with the clear command present.