### PR TITLE
Async loading breaks animations preloads after a few map changes

### DIFF
--- a/config/mastercomfig/cfg/comfig/comfig.cfg
+++ b/config/mastercomfig/cfg/comfig/comfig.cfg
@@ -1183,7 +1183,7 @@ mod_load_vcollide_async 1 // Async vcollide loading
 mod_forcetouchdata 1 // Put all model data into cache on load
 mod_touchalldata 0 // Fully use the async pathway by skipping submodel loading
 mod_forcedata 0 // Async model cache does not force data by default
-alias preload_enable "mod_forcetouchdata 1;mod_touchalldata 1;mod_forcedata 1"
+alias preload_enable "mod_load_anims_async 0;mod_load_mesh_async 0;mod_load_vcollide_async 0;mod_forcetouchdata 1;mod_touchalldata 1;mod_forcedata 1"
 //mod_dynamicunloadtime 150 // How long in seconds a dynamic model can be unused for before being unloaded
 
 // ===============
@@ -1289,6 +1289,7 @@ snd_async_spew_blocking 0 // Disable async spew
 // ------------------
 // '-- Voice Chat --'
 // ------------------
+
 //voice_avggain 0.5 // How fast voice gain should be averaged
 //voice_maxgain 10 // The maximum loudness for voice chat
 //voice_modenable 1 // Enable voice chat
@@ -1299,14 +1300,6 @@ snd_async_spew_blocking 0 // Disable async spew
 //voice_overdrivefadetime 0.4 // How long to fade voice overdrive in seconds (0.0001 to disable)
 //voice_recordtofile 1 // Enable recording voice chat to voice_micdata.wav and voice_decompressed.wav
 //voice_scale 1 // How loud input volume is
-
-setinfo "voice_on" "Command to enable voice chat"
-setinfo "voice_off" "Command to disable voice chat"
-setinfo "voice_toggle" "Command to toggle voice chat"
-
-alias voice_on "voice_enable 1;voice_modenable 1"
-alias voice_off "voice_enable 0;voice_modenable 0"
-alias voice_toggle "toggle voice_enable 1;toggle voice_modenable"
 
 alias sound_low "snd_disable_mixer_duck 1;snd_pitchquality 0;dsp_slow_cpu 1;snd_spatialize_roundrobin 3;dsp_room 0;dsp_facingaway 0;dsp_speaker 0;dsp_water 0;dsp_spatial 0;snd_defer_trace 1"
 alias sound_medium "snd_disable_mixer_duck 0;snd_pitchquality 0;dsp_slow_cpu 1;snd_spatialize_roundrobin 1;dsp_room 0;dsp_facingaway 0;dsp_speaker 50;dsp_water 0;dsp_spatial 40;snd_defer_trace 1"
@@ -1356,6 +1349,7 @@ alias sound_ultra "snd_disable_mixer_duck 0;snd_pitchquality 1;dsp_slow_cpu 0;sn
 // ------------------------
 // Controls Steam Controller/Steam Input
 
+sc_disable 1 // Disable Steam Controller API
 //sc_joystick_map 0 // Scaled Cross analog joystick deadzone and extents
 //sc_joystick_map 1 // Concentric Mapping to Square analog joystick deadzone and extents
 //sc_look_sensitivity_scale 1 // Steam controller sensitivity scale


### PR DESCRIPTION
Also, removing voice toggle commands, they are not necessary at all. The voice_enable command is bugged, if you toggle it during a match you will have to type retry into the console to re-enable the voice system after turning it on again.