### PR TITLE
comfig.cfg update

### DIFF
--- a/config/mastercomfig/cfg/comfig/comfig.cfg
+++ b/config/mastercomfig/cfg/comfig/comfig.cfg
@@ -63,7 +63,7 @@ alias hitboxes_safe "snapshot_buffer_safe;cl_pred_optimize 2;snapshot_buffer" //
 alias hitboxes_accurate "snapshot_buffer_test;cl_pred_optimize 1;snapshot_buffer" // Repredict for small changes in server-side values while still being reliable
 alias hitboxes_low_delay "snapshot_buffer_low;cl_pred_optimize 2;snapshot_buffer" // Minimize difference between interpolation and current server tick
 
-lias network_optimizations_off "cl_interp_all 1;cl_SetupAllBones 1"
+alias network_optimizations_off "cl_interp_all 1;cl_SetupAllBones 1"
 alias network_optimizations_on "cl_interp_all 0;cl_SetupAllBones 0"
 
 alias network_optimizations network_optimizations_on // Not intended to be documented at the moment.

--- a/config/mastercomfig/cfg/comfig/comfig.cfg
+++ b/config/mastercomfig/cfg/comfig/comfig.cfg
@@ -63,6 +63,11 @@ alias hitboxes_safe "snapshot_buffer_safe;cl_pred_optimize 2;snapshot_buffer" //
 alias hitboxes_accurate "snapshot_buffer_test;cl_pred_optimize 1;snapshot_buffer" // Repredict for small changes in server-side values while still being reliable
 alias hitboxes_low_delay "snapshot_buffer_low;cl_pred_optimize 2;snapshot_buffer" // Minimize difference between interpolation and current server tick
 
+lias network_optimizations_off "cl_interp_all 1;cl_SetupAllBones 1"
+alias network_optimizations_on "cl_interp_all 0;cl_SetupAllBones 0"
+
+alias network_optimizations network_optimizations_on // Not intended to be documented at the moment.
+
 // -------------------
 // '-- Packet Size --'
 // -------------------

--- a/config/mastercomfig/cfg/comfig/comfig.cfg
+++ b/config/mastercomfig/cfg/comfig/comfig.cfg
@@ -28,6 +28,7 @@ cl_pred_optimize 2 // Optimize for not copying data if did not receive a network
 // '-- Snapshot Buffer --'
 // -----------------------
 // Tuning client-server communication and interpolation
+
 alias interp_congestion_high "cl_interp .090909;setinfo cl_interp .090909"
 alias interp_congestion_safe "cl_interp .060606;setinfo cl_interp .060606"
 alias interp_congestion_low "cl_interp .030303;setinfo cl_interp .030303"
@@ -52,8 +53,8 @@ alias packet_rate packet_rate_standard
 
 alias snapshot_buffer_high "cl_interp_ratio 3;setinfo cl_interp_ratio 3;interp_high"
 alias snapshot_buffer_safe "cl_interp_ratio 2;setinfo cl_interp_ratio 2;interp_safe"
-alias snapshot_buffer_test "cl_interp_ratio 1;setinfo cl_interp_ratio 1;interp_safe"
 alias snapshot_buffer_low "cl_interp_ratio 1;setinfo cl_interp_ratio 1;interp_low"
+alias snapshot_buffer_test "cl_interp_ratio 1;setinfo cl_interp_ratio 1;interp_safe"
 
 alias snapshot_buffer
 snapshot_buffer_safe
@@ -61,11 +62,6 @@ snapshot_buffer_safe
 alias hitboxes_safe "snapshot_buffer_safe;cl_pred_optimize 2;snapshot_buffer" // Use reliable buffer for no errors in most situations
 alias hitboxes_accurate "snapshot_buffer_test;cl_pred_optimize 1;snapshot_buffer" // Repredict for small changes in server-side values while still being reliable
 alias hitboxes_low_delay "snapshot_buffer_low;cl_pred_optimize 2;snapshot_buffer" // Minimize difference between interpolation and current server tick
-
-alias network_optimizations_off "cl_interp_all 1;cl_SetupAllBones 1"
-alias network_optimizations_on "cl_interp_all 0;cl_SetupAllBones 0"
-
-alias network_optimizations network_optimizations_on // Not intended to be documented at the moment.
 
 // -------------------
 // '-- Packet Size --'
@@ -1378,7 +1374,6 @@ alias packet_rate=congestion "alias packet_rate packet_rate_congestion"
 alias packet_rate=standard "alias packet_rate packet_rate_standard"
 alias snapshot_buffer=high "alias snapshot_buffer snapshot_buffer_high"
 alias snapshot_buffer=safe "alias snapshot_buffer snapshot_buffer_safe"
-alias snapshot_buffer=balanced "alias snapshot_buffer snapshot_buffer_balanced"
 alias snapshot_buffer=low "alias snapshot_buffer snapshot_buffer_low"
 alias packet_size=conservative "alias packet_size packet_size_conservative"
 alias packet_size=lowend "alias packet_size packet_size_lowend"


### PR DESCRIPTION
It is unnecessary to have the network_optimizations module at this point.
cl_interp_all and cl_SetupAllBones are defaulted to 0.