### PR TITLE
Do not block game_overrides_once in benchmarks

### DIFF
--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -15,7 +15,7 @@ Thus, it's highly appreciated to benchmark mastercomfig and any changes you make
 1. Download [the benchmark file](https://mega.nz/#!f8tlhDhR!nYgghqybOK15ObUykEczewB3242XHb_bJ4JP0rv1q6k).
 2. Move it to the `tf/` folder.
 3. Launch the game.
-4. Enter `block_game_overrides_once;timedemo benchmark_test`
+4. Enter `timedemo benchmark_test` in the console.
 5. Record your timedemo output from the console `X frames X seconds X fps (X ms/f) X fps variability`.
 6. Repeat `timedemo benchmark_test` as many times as you like to decrease the effects of systemic variation.
 


### PR DESCRIPTION
block_game_overrides_once will not exist if the user does not enter a match before running it. Also, there is nothing on the current game_overrides_once alias, so blocking it is useless.