### PR TITLE
launch_options.md

### DIFF
--- a/docs/customization/launch_options.md
+++ b/docs/customization/launch_options.md
@@ -19,11 +19,10 @@ Read below about optional launch options and choosing your own DXLevel.
 ## DXLevel Launch Options
 
 === "Windows"
-
 !!! info
-    These launch options should be added to first launch, and then removed.
-
-    * **-dxlevel 100** : Use hardware to determine graphics capabilities.
+    This launch option should be added to first launch, and after quitting the game, be removed.
+!!!
+* **-dxlevel 100** : Use hardware to determine graphics capabilities.
 === "macOS/Linux"
     The DXLevel is automatically determined and cannot be set.
 


### PR DESCRIPTION
My idea here is to agroup "Windows" and "macOS/Linux" together, and don't put "-dxlevel 100" into the info card. I don't know if the formatting is correct, but I think it is.