### PR TITLE
Remove no extra models addon description from docs

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -28,7 +28,6 @@ description: A list of all mastercomfig features.
 * Optimized ropes
 * Optimized OpenGL
 * Optimized item panel loading
-* Removed extra cosmetic map models (UFOs, invasion posters, rockets)
 
 ## Start up
 * Cleaned up texture preload list


### PR DESCRIPTION
It was removed in 8.102.0