### PR TITLE
Add temporary info on how to re-enable chat

### DIFF
--- a/docs/next_steps/troubleshoot.md
+++ b/docs/next_steps/troubleshoot.md
@@ -40,7 +40,7 @@ alias game_overrides_once_c hud_reloadscheme
 
 The command will only run on the first time you spawn in a match.
 
-## Last update disabled my chat
+## My chat is disabled
 
 One of [recent TF2 updates](https://www.teamfortress.com/post.php?id=62459) introduced new commands to disable chat. mastercomfig was updated shortly after to accommodate to this change. In the result, the Very Low preset disables chat completely. If you are using Very Low preset or `messages=off` module, you can fix that by adding `messages=on` to your `modules.cfg` file. To disable chat the old way you can use `hud_saytext_time 0` command.
 

--- a/docs/next_steps/troubleshoot.md
+++ b/docs/next_steps/troubleshoot.md
@@ -42,7 +42,7 @@ The command will only run on the first time you spawn in a match.
 
 ## My chat is disabled
 
-One of [recent TF2 updates](https://www.teamfortress.com/post.php?id=62459) introduced new commands to disable chat. mastercomfig was updated shortly after to accommodate to this change. In the result, the Very Low preset disables chat completely. If you are using Very Low preset or `messages=off` module, you can fix that by adding `messages=on` to your `modules.cfg` file. To disable chat the old way you can use `hud_saytext_time 0` command.
+[A TF2 update](https://www.teamfortress.com/post.php?id=62459) introduced the ability to completely disable text chat. mastercomfig was updated shortly after to accommodate this change, with the Very Low preset disabling chat completely. If you are using Very Low preset or the `messages=off` module, you can re-enable chat by adding `messages=on` to your `modules.cfg` file. To disable chat the old way you can use the `hud_saytext_time 0` command.
 
 
 ## TF2 crashes when entering a Competitive Mode match

--- a/docs/next_steps/troubleshoot.md
+++ b/docs/next_steps/troubleshoot.md
@@ -42,7 +42,7 @@ The command will only run on the first time you spawn in a match.
 
 ## Last update disabled my chat
 
-One of [recent TF2 updates](https://www.teamfortress.com/post.php?id=62459) introduced new commands to disable chat. mastercomfig was updated shortly after to accomodate to this change. In the result, the Very Low preset disables chat completely. If you are using Very Low preset or `messages=off` module, you can fix that by adding `messages=on` to your `modules.cfg` file.
+One of [recent TF2 updates](https://www.teamfortress.com/post.php?id=62459) introduced new commands to disable chat. mastercomfig was updated shortly after to accommodate to this change. In the result, the Very Low preset disables chat completely. If you are using Very Low preset or `messages=off` module, you can fix that by adding `messages=on` to your `modules.cfg` file. To disable chat the old way you can use `hud_saytext_time 0` command.
 
 
 ## TF2 crashes when entering a Competitive Mode match

--- a/docs/next_steps/troubleshoot.md
+++ b/docs/next_steps/troubleshoot.md
@@ -40,6 +40,11 @@ alias game_overrides_once_c hud_reloadscheme
 
 The command will only run on the first time you spawn in a match.
 
+## Last update disabled my chat
+
+One of [recent TF2 updates](https://www.teamfortress.com/post.php?id=62459) introduced new commands to disable chat. mastercomfig was updated shortly after to accomodate to this change. In the result, the Very Low preset disables chat completely. If you are using Very Low preset or `messages=off` module, you can fix that by adding `messages=on` to your `modules.cfg` file.
+
+
 ## TF2 crashes when entering a Competitive Mode match
 
 According to the [Official FAQ](https://www.teamfortress.com/meetyourmatch/faq/), Competitive Mode requires DirectX 9. Make sure your `dxlevel` is set to 90 or above (see [here](../customization/launch_options/#dxlevel-launch-options) for instructions).


### PR DESCRIPTION
I believe this could become one of frequently asked questions, in my opinion it is best to add it for short span of ~2 to 4 months so users who don't update regularly will have chance to see it.