### PR TITLE
 Prevent fog cvar spew in console on startup

### DIFF
--- a/config/mastercomfig/cfg/comfig/comfig.cfg
+++ b/config/mastercomfig/cfg/comfig/comfig.cfg
@@ -10,6 +10,8 @@
 
 // Recommended launch options: -novid -nojoy -nosteamcontroller -nohltv -particles 1
 
+sv_cheats 1 // Prevent fog cvar spew in console on startup
+
 // =================
 // '--- Network ---'
 // =================

--- a/config/mastercomfig/cfg/comfig/finalize.cfg
+++ b/config/mastercomfig/cfg/comfig/finalize.cfg
@@ -1,3 +1,4 @@
 // Runs after user configs and addons
 mat_savechanges;host_writeconfig // Make sure we init next time with our material system cvars to prevent reloads
 block_antialias
+sv_cheats 0 // Disable sv_cheats so people on local games can earn achievements without intervention


### PR DESCRIPTION
This was present in old versions of mastercomfig but it was removed later. I am open for discussion as I do not know reason why it was removed. I think enabling it to prevent error messages and then disabling later in cfg is a reasonable fix for the problem that is cheat protected commands executing and giving errors.