### PR TITLE
Make "cl_downloadfilter all" the default setting.

### DIFF
--- a/config/mastercomfig/cfg/comfig/comfig.cfg
+++ b/config/mastercomfig/cfg/comfig/comfig.cfg
@@ -174,7 +174,7 @@ alias download_nosounds"cl_downloadfilter nosounds"
 alias download_mapsonly"cl_downloadfilter mapsonly"
 alias download_none"cl_downloadfilter none"
 
-alias download download_all
+alias download
 
 // -------------------
 // '-- Matchmaking --'

--- a/config/mastercomfig/cfg/comfig/comfig.cfg
+++ b/config/mastercomfig/cfg/comfig/comfig.cfg
@@ -174,7 +174,7 @@ alias download_nosounds"cl_downloadfilter nosounds"
 alias download_mapsonly"cl_downloadfilter mapsonly"
 alias download_none"cl_downloadfilter none"
 
-alias download download_mapsonly
+alias download download_all
 
 // -------------------
 // '-- Matchmaking --'

--- a/config/templates/modules/modules.cfg
+++ b/config/templates/modules/modules.cfg
@@ -40,7 +40,7 @@
 //bandwidth=1.5Mbps
 // 8.0Mbps, 6.0Mbps, 4.0Mbps, 3.0Mbps, 2.5Mbps, 2.0Mbps, 1.5Mbps, 1.0Mbps, 768Kbps, 512Kbps, 384Kbps, 192Kbps, 128Kbps
 
-//download=mapsonly
+//download=all
 // all, nosounds, mapsonly, none
 
 //********************************************************************************

--- a/docs/customization/modules.md
+++ b/docs/customization/modules.md
@@ -98,7 +98,7 @@ Default setting: **`bandwidth=1.5Mbps`** (all presets).
 
 ### Downloads
 
-Default setting: **`download=mapsonly`** (all presets).
+Default setting: **`download=all`** (all presets).
 
 * **`download=all`**: Download all custom files from servers.
 * **`download=nosounds`**: Download everything but sounds from servers.


### PR DESCRIPTION
This pull request makes the client cvar "cl_download filter all" the default module setting. The reason for this change is to eliminate the confusion on why clients get a giant "ERROR" for when they do not have required assets on a community server. This ensures that their game is running as intended and avoids obstructing game-play by not having the annoying "ERROR" sign.