### PR TITLE
Update launch options descriptions

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -80,7 +80,7 @@ There are currently 4 categories for launch options:
   elsewhere as their effects are not clear
 
 Put your launch option in the appropriate section and if it's in the
-`Launch Options` section, add it to the launch options line for easy copying.
+`Recommended` section, add it to the launch options line for easy copying.
 
 Here's lists of launch options to help you out:
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -70,7 +70,7 @@ letter.
 
 There are currently 4 categories for launch options:
 
-* `Launch Options`: These are launch options everyone should be using, as they
+* `Recommended`: These are launch options everyone should be using, as they
   benefit all users
 * `Extra`: These are launch options people find to be personal preference or for
   use cases that cannot be applied to all users

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -72,13 +72,13 @@ letter.
 
 There are currently 4 categories for launch options:
 
-* `Launch Options`: These are launch options everyone should be using, as they benefit all users
+* `Recommended`: These are launch options everyone should be using, as they benefit all users
 * `Extra`: These are launch options people find to be personal preference or for use cases that cannot be applied to all users
 * `Uncommon`: These are launch options most people will not use, but will still satisfy a valid use case
 * `Experimental`: These are launch options that are being tested to be moved elsewhere as their effects are not clear
 
 Put your launch option in the appropriate section and if it's in the
-`Launch Options` section, add it to the launch options line for easy copying.
+`Recommended` section, add it to the launch options line for easy copying.
 
 Here's lists of launch options to help you out:
 

--- a/docs/customization/launch_options.md
+++ b/docs/customization/launch_options.md
@@ -38,9 +38,9 @@ Read below about optional launch options and choosing your own DXLevel.
 
     The DXLevel is automatically determined and cannot be set.
 
-## List of Launch Options
+## Recommended Launch Options
 
-**Recommended**: `-novid -nojoy -nosteamcontroller -nohltv -particles 1`
+`-novid -nojoy -nosteamcontroller -nohltv -particles 1`
 
 * **-novid** : disables Valve startup logo, saves time
 * **-nojoy** : stops Joystick system from starting up, faster startup and less memory usage


### PR DESCRIPTION
Reason: I think it's weird that it says "launch options" is a category for launch options.