### PR TITLE
Make "tf2 documentation generation" a bit more readable

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -87,7 +87,7 @@ Here's lists of launch options to help you out:
 * [Windows](https://docs.mastercomfig.com/en/latest/tf2/launchopts_win/)
 * [Linux](https://docs.mastercomfig.com/en/latest/tf2/launchopts_linux/)
 
-Information about generating them can be found [here](https://docs.mastercomfig.com/en/latest/tf2/#launch_options).
+Information about generating them can be found [here](https://docs.mastercomfig.com/en/latest/tf2/#making-your-own-launch-options-list).
 
 ##### Comfig and presets
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -85,7 +85,7 @@ Here's lists of launch options to help you out:
 * [Windows](https://docs.mastercomfig.com/en/latest/tf2/launchopts_win/)
 * [Linux](https://docs.mastercomfig.com/en/latest/tf2/launchopts_linux/)
 
-Information about generating them can be found [here](https://docs.mastercomfig.com/en/latest/tf2/#launch_options).
+Information about generating them can be found [here](https://docs.mastercomfig.com/en/latest/tf2/#making-your-own-launch-options-list).
 
 #### Comfig and presets
 

--- a/docs/tf2/README.md
+++ b/docs/tf2/README.md
@@ -1,12 +1,18 @@
 # TF2 documentation generation
 
-## cvarlist_linux
+## Premade lists
 
-A list of Linux TF2 cvars.
+You can view premade cvar lists, launch options lists and  hidden cvar list.
 
-## cvarlist_win
+[Linux cvar list](https://docs.mastercomfig.com/en/latest/tf2/cvarlist_linux)
 
-A list of Windows TF2 cvars.
+[Linux launch option list](https://docs.mastercomfig.com/en/latest/tf2/cvarlist_linux)
+
+[Windows cvar list](https://docs.mastercomfig.com/en/latest/tf2/cvarlist_win)
+
+[Windows Launch option list](https://docs.mastercomfig.com/en/latest/tf2/launchopts_win)
+
+[Hidden cvar list](https://docs.mastercomfig.com/en/latest/tf2/hiddencvars)
 
 ## Making your own cvar list
 
@@ -15,12 +21,12 @@ A list of Windows TF2 cvars.
 3. Remove launch options, add mastercomfig again.
 4. Copy and paste `tf/console.log` cvarlist.
 
-## hiddencvars
+## Making your own hidden cvar list
 
 Use the [sm_cvarlist](https://forums.alliedmods.net/showthread.php?p=1298262) SourceMod plugin.
 
-## launch_options
+## Making your own launch options list
 
-Get Windows launch options: [GetLaunchOptions.bat](https://github.com/AveYo/D-OPTIMIZER/blob/archive/GetLaunchOptions.bat)
+On Windows you can use[GetLaunchOptions.bat](https://github.com/AveYo/D-OPTIMIZER/blob/archive/GetLaunchOptions.bat) script.
 
-Get Linux launch options: `find . -type f \( -name "*.so" -o -name "hl2_linux" \) -print0 | xargs -0 strings | grep "^\-[a-ZA-Z]" | awk 'NF==1' | sort -u > launch_options.txt`
+On Linux you can use following commands: `find . -type f \( -name "*.so" -o -name "hl2_linux" \) -print0 | xargs -0 strings | grep "^\-[a-ZA-Z]" | awk 'NF==1' | sort -u > launch_options.txt`

--- a/docs/tf2/README.md
+++ b/docs/tf2/README.md
@@ -27,6 +27,6 @@ Use the [sm_cvarlist](https://forums.alliedmods.net/showthread.php?p=1298262) So
 
 ## Making your own launch options list
 
-On Windows you can use[GetLaunchOptions.bat](https://github.com/AveYo/D-OPTIMIZER/blob/archive/GetLaunchOptions.bat) script.
+On Windows you can use [GetLaunchOptions.bat](https://github.com/AveYo/D-OPTIMIZER/blob/archive/GetLaunchOptions.bat) script.
 
 On Linux you can use following commands: `find . -type f \( -name "*.so" -o -name "hl2_linux" \) -print0 | xargs -0 strings | grep "^\-[a-ZA-Z]" | awk 'NF==1' | sort -u > launch_options.txt`

--- a/docs/tf2/README.md
+++ b/docs/tf2/README.md
@@ -2,17 +2,13 @@
 
 ## Premade lists
 
-You can view premade cvar lists, launch options lists and  hidden cvar list.
+You can view premade cvarlists, launch options lists and hidden cvarlists.
 
-[Linux cvar list](https://docs.mastercomfig.com/en/latest/tf2/cvarlist_linux)
-
-[Linux launch option list](https://docs.mastercomfig.com/en/latest/tf2/cvarlist_linux)
-
-[Windows cvar list](https://docs.mastercomfig.com/en/latest/tf2/cvarlist_win)
-
-[Windows Launch option list](https://docs.mastercomfig.com/en/latest/tf2/launchopts_win)
-
-[Hidden cvar list](https://docs.mastercomfig.com/en/latest/tf2/hiddencvars)
+* [Windows cvarlist](https://docs.mastercomfig.com/en/latest/tf2/cvarlist_win)
+* [Windows Launch option list](https://docs.mastercomfig.com/en/latest/tf2/launchopts_win)
+* [Linux cvarlist](https://docs.mastercomfig.com/en/latest/tf2/cvarlist_linux)
+* [Linux launch option list](https://docs.mastercomfig.com/en/latest/tf2/launchopts_linux)
+* [Hidden cvarlist](https://docs.mastercomfig.com/en/latest/tf2/hiddencvars)
 
 ## Making your own cvar list
 

--- a/docs/tf2/README.md
+++ b/docs/tf2/README.md
@@ -27,6 +27,6 @@ Use the [sm_cvarlist](https://forums.alliedmods.net/showthread.php?p=1298262) So
 
 ## Making your own launch options list
 
-On Windows you can use [GetLaunchOptions.bat](https://github.com/AveYo/D-OPTIMIZER/blob/archive/GetLaunchOptions.bat) script.
+On Windows you can use the [GetLaunchOptions.bat](https://github.com/AveYo/D-OPTIMIZER/blob/archive/GetLaunchOptions.bat) script.
 
 On Linux you can use following commands: `find . -type f \( -name "*.so" -o -name "hl2_linux" \) -print0 | xargs -0 strings | grep "^\-[a-ZA-Z]" | awk 'NF==1' | sort -u > launch_options.txt`

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -35,13 +35,13 @@ nav:
         - Update: 'next_steps/update.md'
     - TF2 Documentation:
         - Misconceptions: 'tf2/misconceptions.md'
+        - Generating TF2 Data: 'tf2/README.md'
         - Console Variables - Windows: 'tf2/cvarlist_win.md'
         - Console Variables - Linux: 'tf2/cvarlist_linux.md'
         - Hidden Console Variables: 'tf2/hiddencvars.md'
         - Launch Options - Windows: 'tf2/launchopts_win.md'
         - Launch Options - Linux: 'tf2/launchopts_linux.md'
         - Silly Launch Options: 'tf2/silly_launch_options.md'
-        - Generating TF2 Data: 'tf2/README.md'
 markdown_extensions:
     - admonition
     - smarty

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -35,13 +35,13 @@ nav:
         - Update: 'next_steps/update.md'
     - TF2 Documentation:
         - Misconceptions: 'tf2/misconceptions.md'
-        - Generating TF2 Data: 'tf2/README.md'
         - Console Variables - Windows: 'tf2/cvarlist_win.md'
         - Console Variables - Linux: 'tf2/cvarlist_linux.md'
         - Hidden Console Variables: 'tf2/hiddencvars.md'
         - Launch Options - Windows: 'tf2/launchopts_win.md'
         - Launch Options - Linux: 'tf2/launchopts_linux.md'
         - Silly Launch Options: 'tf2/silly_launch_options.md'
+        - Generating TF2 Data: 'tf2/README.md'
 markdown_extensions:
     - admonition
     - smarty


### PR DESCRIPTION
Also changed order, so it appears before the cvar, launchtops and hidden cvar lists.