### PR TITLE
Add move_bind to docs, add Miscelaneous modules section

### DIFF
--- a/docs/customization/custom_configs.md
+++ b/docs/customization/custom_configs.md
@@ -47,24 +47,6 @@ mastercomfig now supports selecting a preset after download. Add a file to your 
 * low
 * very-low
 
-## Null cancelling movement addon binds
-
-The default binding for the null cancelling movement addon is WASD, but you can use `user/modules.cfg` to select a new binding:
-
-* `move_bind=wasd`: The standard WASD layout (default).
-* `move_bind=esdf`: The alternative ESDF layout.
-* `move_bind=zqsd`: WASD for AZERTY keyboards.
-* `move_bind=arrows`: The classic arrow keys layout.
-* `move_bind=asdf`: The classic ASDF layout (A/S forward/back, D/F left/right).
-* `move_bind=vim`: Vim mode! HJKL, as in Vim (K/J forward/back, H/L left/right).
-
-If you want a different or more advanced binding, you can use the aliases:
-
-* Forward: `+mf`
-* Left: `+ml`
-* Backward: `+mb`
-* Right: `+mr`
-
 ## Optional Aliases
 
 !!! warning

--- a/docs/customization/custom_configs.md
+++ b/docs/customization/custom_configs.md
@@ -55,7 +55,7 @@ The default binding for the null cancelling movement addon is WASD, but you can 
 * `move_bind=esdf`: The alternative ESDF layout.
 * `move_bind=zqsd`: WASD for AZERTY keyboards.
 * `move_bind=arrows`: The classic arrow keys layout.
-* `move_bind=asdf`: The classic ASDF layout (A/S forward/back, D/F left/right)
+* `move_bind=asdf`: The classic ASDF layout (A/S forward/back, D/F left/right).
 * `move_bind=vim`: Vim mode! HJKL, as in Vim (K/J forward/back, H/L left/right).
 
 If you want a different or more advanced binding, you can use the aliases:

--- a/docs/customization/modules.md
+++ b/docs/customization/modules.md
@@ -558,26 +558,6 @@ Default setting: **`dynamic_background=off`** (all presets).
 * **`dynamic_background=itemtest`**: `itemtest` map background for preloading (auto disconnects).
 * **`dynamic_background=dustbowl`**: Live Dustbowl map main menu background on startup.
 
-### Logo
-
-Controls the mastercomfig logo which appears in console on start up.
-
-Default setting: **`logo=on`** (all presets, except Very Low).
-
-* **`logo=off`**: Does not print logo in console on startup.
-* **`logo=on`**: Prints logo in console on startup.
-
-## Mod Support
-
-Ensures compatibility with animation and model mods.
-
-Default setting: **`mod_support=on`** (all presets).
-
-You may want to also enable preloading using the [Map Background module](#map-background).
-
-* **`mod_support=off`**: Enables better file system performance for faster first map loads, at the cost of animation and model mods causing crashes.
-* **`mod_support=on`**: Disables file system optimizations for the first map load, making it slower, but fixes crashes caused by animation and model mods.
-
 ## Sound modules
 
 ### Sound
@@ -607,3 +587,41 @@ Default setting: **`voice_chat=on`** (all presets, except Very Low).
 
 * **`voice_chat=off`**: Disables the in-game voice chat system.
 * **`voice_chat=on`**: Enables the in-game voice chat system.
+
+## Miscellaneous modules
+
+### Logo
+
+Controls the mastercomfig logo which appears in console on start up.
+
+Default setting: **`logo=on`** (all presets, except Very Low).
+
+* **`logo=off`**: Does not print logo in console on startup.
+* **`logo=on`**: Prints logo in console on startup.
+
+### Mod Support
+
+Ensures compatibility with animation and model mods.
+
+Default setting: **`mod_support=on`** (all presets).
+
+You may want to also enable preloading using the [Map Background module](#map-background).
+
+* **`mod_support=off`**: Enables better file system performance for faster first map loads, at the cost of animation and model mods causing crashes.
+* **`mod_support=on`**: Disables file system optimizations for the first map load, making it slower, but fixes crashes caused by animation and model mods.
+
+### Movement Binds
+
+!!! warning
+    This module requires the Null Movement addon in order to function
+
+Changes the keys that are used to move while the Null Movement addon is installed, if your preferred movement keys are not listed here, you can edit them manually outside of modules.cfg. Instructions for doing so can be found [here](https://docs.mastercomfig.com/en/latest/customization/custom_configs/#null-cancelling-movement-addon-binds).
+
+Default setting: **`move_bind=wasd`** (all presets).
+
+* **`move_bind=wasd`**: Set movement keys to WASD (default).
+* **`move_bind=esdf`**: Set movement keys to ESDF.
+* **`move_bind=zqsd`**: Set movement keys to ZQSD (default for AZERTY keyboards).
+* **`move_bind=arrows`**: Set movement keys to the Arrow Keys.
+* **`move_bind=asdf`**: Set movement keys to ASDF (A/S forward/back, D/F left/right).
+* **`move_bind=vim`**: Set movement keys to HJKL (K/J forward/back, H/L left/right).

--- a/docs/customization/modules.md
+++ b/docs/customization/modules.md
@@ -615,7 +615,20 @@ You may want to also enable preloading using the [Map Background module](#map-ba
 !!! warning
     This module requires the Null Movement addon in order to function
 
-Changes the keys that are used to move while the Null Movement addon is installed, if your preferred movement keys are not listed here, you can edit them manually outside of modules.cfg. Instructions for doing so can be found [here](https://docs.mastercomfig.com/en/latest/customization/custom_configs/#null-cancelling-movement-addon-binds).
+Changes the keys that are used to move while the Null Movement addon is installed. 
+If your preferred movement keys are not listed here, you can edit them manually by binding these aliases:
+
+* Forward: `+mf`
+* Left: `+ml`
+* Backward: `+mb`
+* Right: `+mr`
+
+Example:
+
+* Forward: `bind w +mf`
+* Left: `bind a +ml`
+* Backward: `bind s +mb`
+* Right: `bind d +mr`
 
 Default setting: **`move_bind=wasd`** (all presets).
 


### PR DESCRIPTION
-Logo and Mod Support have been moved to the new Miscellaneous modules section 
-Move bind added to this section as well
-Fix a missing period in custom configs part of docs
-Mod support is no longer its own separate section, as it is part of Miscellaneous modules