### PR TITLE
Outlines module changes

### DIFF
--- a/config/cfg/presets/medium-high.cfg
+++ b/config/cfg/presets/medium-high.cfg
@@ -24,7 +24,7 @@ jigglebones=on
 textures=high
 ropes=low
 hud_player_model=off
-outlines=low
+outlines=medium
 sound=high
 
 echo"Medium High preset selected"

--- a/config/cfg/presets/medium.cfg
+++ b/config/cfg/presets/medium.cfg
@@ -24,7 +24,7 @@ jigglebones=off
 textures=medium
 ropes=off
 hud_player_model=off
-outlines=low
+outlines=medium
 sound=medium
 
 tf_quest_map_tuner_wobble_magnitude 0 // Disable the red tuner on the contracker

--- a/config/mastercomfig/cfg/comfig/comfig.cfg
+++ b/config/mastercomfig/cfg/comfig/comfig.cfg
@@ -1174,8 +1174,8 @@ fov_desired 90 // See more of the battlefield
 //cl_use_tournament_specgui 1 // Use advanced tournament UI in spectator tournament mode
 
 alias outlines_off"glow_outline_effect_enable 0;tf_enable_glows_after_respawn 0;tf_spec_xray_disable 1"
-alias outlines_low"glow_outline_effect_enable 0;tf_enable_glows_after_respawn 1;tf_spec_xray_disable 0"
-alias outlines_medium"glow_outline_effect_enable 1;tf_enable_glows_after_respawn 0;tf_spec_xray_disable 1"
+alias outlines_low"glow_outline_effect_enable 1;tf_enable_glows_after_respawn 0;tf_spec_xray_disable 1"
+alias outlines_medium"glow_outline_effect_enable 1;tf_enable_glows_after_respawn 1;tf_spec_xray_disable 1"
 alias outlines_high"glow_outline_effect_enable 1;tf_enable_glows_after_respawn 1;tf_spec_xray_disable 0"
 
 // ===========================

--- a/config/mastercomfig/cfg/comfig/comfig.cfg
+++ b/config/mastercomfig/cfg/comfig/comfig.cfg
@@ -1712,7 +1712,7 @@ alias restore_config"exec autoexec.cfg"
 
 alias game_overrides"cheap_water_override;detail_props_override"
 
-alias game_overrides_once "match_hud_once;game_overrides_once_c"
+alias game_overrides_once"match_hud_once;game_overrides_once_c"
 block_game_overrides_once
 
 alias version_comfig"echo mastercomfig version: 9.0.1 | October 3, 2020"

--- a/data/preset_modules.json
+++ b/data/preset_modules.json
@@ -228,9 +228,10 @@
     "very-low": "off"
   },
   "outlines": {
-    "default": "low",
-    "very-low": "off",
-    "low": "off",
+    "default": "off",
+    "medium-low": "low",
+    "medium": "medium",
+    "medium-high": "medium",
     "high": "high",
     "ultra": "high"
   },

--- a/docs/customization/modules.md
+++ b/docs/customization/modules.md
@@ -558,10 +558,10 @@ Controls the outlines that appear through walls for players and some objectives 
 
 Default setting: based on which preset you are currently using.
 
-* **`outlines=off`**: Disable outlines and nametags.
-* **`outlines=low`**: Enable nametags, disable outlines.
-* **`outlines=medium`**: Disable nametags and player outlines, enable objective outlines.
-* **`outlines=high`**: Enable nametags and outlines.
+* **`outlines=off`**: Disable all outlines and nametags.
+* **`outlines=low`**: Enable objective outlines, disable nametags and disable spectator outlines.
+* **`outlines=medium`**: Enable objective outlines, enable nametags and disable spectator outlines.
+* **`outlines=high`**: Enable all outlines and nametags.
 
 ### Map Background
 


### PR DESCRIPTION
The low level was activating more outlines/nametags than the medium level. To correct that, low level now only enables objective outlines and medium level only disables spectator outlines. I also changed the outlines module to be at the medium level by default on the medium and medium-high presets.