### PR TITLE
Correct hidden cvar count in Docs

### DIFF
--- a/docs/tf2/hiddencvars.md
+++ b/docs/tf2/hiddencvars.md
@@ -432,5 +432,5 @@ weapon_medigun_construction_rate         : 10       : , "sv", "cheat", "rep", "l
 weapon_medigun_damage_modifier           : 1.5      : , "sv", "cheat", "rep", "launcher" : Scales the damage a player does while being healed with the medigun.
 weapon_medigun_resist_num_chunks         : 4        : , "sv", "cheat", "rep", "launcher" : How many uber bar chunks the vaccinator has.
 --------------
-426 total convars/concommands
+424 total convars/concommands
 ```


### PR DESCRIPTION
There are 424 cvars in this list, not 426. Additionally, running `sm_cvarlist /unlisted /defaults /file` on the current windows tf2 client returns the same list, ending with `424 total convars/concommands`.