### PR TITLE
Replace "No muzzleflash" with a better alternative

### DIFF
--- a/docs/customization/see_also.md
+++ b/docs/customization/see_also.md
@@ -19,7 +19,7 @@ Here are a few awesome TF2 modifications:
   — Get cleaner particles for explosions
 
 * [No muzzle flashes](https://github.com/ghost-420/no-muzzleflashes)
-  — Removes muzzleflash sprites and particles from all weapons, and selectively from sentry guns
+  — Removes muzzleflash sprites and particles from all weapons, and from sentry guns (if preferred)
 
 * [Particle Limitation Pack](https://www.teamfortress.tv/22586/particle-limitation-pack)
   — Reduce certain particles

--- a/docs/customization/see_also.md
+++ b/docs/customization/see_also.md
@@ -19,7 +19,7 @@ Here are a few awesome TF2 modifications:
   — Get cleaner particles for explosions
 
 * [No muzzle flashes](https://github.com/ghost-420/no-muzzleflashes)
-  — Removes muzzleflash sprites and particles from all weapons, and selectively from sentry guns. 
+  — Removes muzzleflash sprites and particles from all weapons, and selectively from sentry guns
 
 * [Particle Limitation Pack](https://www.teamfortress.tv/22586/particle-limitation-pack)
   — Reduce certain particles
@@ -50,4 +50,4 @@ Here are a few awesome TF2 modifications:
   — Replace the dynamic crosshair resize of the Ambassador inaccuracy indicator with a static crosshair
 
 * [Loadouts Script](https://github.com/juniorsgithub/tf2-loadouts-script)
-  — An "advanced" TF2 loadouts and resupply script.
+  — An "advanced" TF2 loadouts and resupply script

--- a/docs/customization/see_also.md
+++ b/docs/customization/see_also.md
@@ -19,7 +19,7 @@ Here are a few awesome TF2 modifications:
   — Get cleaner particles for explosions
 
 * [No muzzle flashes](https://github.com/ghost-420/no-muzzleflashes)
-  — Removes muzzleflash sprites and particles from all weapons, and selectively, sentry guns. 
+  — Removes muzzleflash sprites and particles from all weapons, and selectively from sentry guns. 
 
 * [Particle Limitation Pack](https://www.teamfortress.tv/22586/particle-limitation-pack)
   — Reduce certain particles

--- a/docs/customization/see_also.md
+++ b/docs/customization/see_also.md
@@ -18,8 +18,8 @@ Here are a few awesome TF2 modifications:
 * [No explosion smoke script](https://www.teamfortress.tv/25647/no-explosion-smoke-script)
   — Get cleaner particles for explosions
 
-* [No muzzleflash](https://www.teamfortress.tv/25647/no-explosion-smoke-script/?page=7#182)
-  — Comes with no explosion smoke script and removes muzzle flashes from guns
+* [No muzzle flashes](https://github.com/ghost-420/no-muzzleflashes)
+  — Removes muzzleflash sprites and particles from all weapons, and selectively, sentry guns. 
 
 * [Particle Limitation Pack](https://www.teamfortress.tv/22586/particle-limitation-pack)
   — Reduce certain particles


### PR DESCRIPTION
The previous link given is an incomplete solution.
You can test this by using the Soda Popper, and any Minigun-type weapon.

Note: I also have an explosion smoke replacement in my 'custom' folder, and it works fine with my mod.