### PR TITLE
Change how match_hud_off works to actually disable the match HUD

### DIFF
--- a/config/mastercomfig/cfg/comfig/comfig.cfg
+++ b/config/mastercomfig/cfg/comfig/comfig.cfg
@@ -929,9 +929,10 @@ alias hud_panels_on"tf_healthicon_height_offset 10;tf_hud_target_id_offset 0"
 
 alias hud_panels hud_panels_on
 
-alias match_hud_disable"tf_use_match_hud 0"
+alias match_hud_alias"tf_use_match_hud 0"
+alias match_hud_alias2"alias match_hud_off match_hud_alias"
 
-alias match_hud_off"tf_use_match_hud 1;alias match_hud_once match_hud_disable"
+alias match_hud_off"tf_use_match_hud 1;alias match_hud_once match_hud_alias"
 alias match_hud_on"tf_use_match_hud 1;alias match_hud_once"
 
 alias match_hud match_hud_on

--- a/config/mastercomfig/cfg/comfig/game_overrides.cfg
+++ b/config/mastercomfig/cfg/comfig/game_overrides.cfg
@@ -1,7 +1,7 @@
 game_overrides // Run aliased game overrides
 game_overrides_c // Run custom aliased game overrides
 game_overrides_once // Run commands that should be run once
-alias block_game_overrides_once"alias game_overrides_once";block_game_overrides_once // Block game_overrides_once
+alias block_game_overrides_once"alias game_overrides_once;match_hud_alias2";block_game_overrides_once // Block game_overrides_once and set match_hud_off to actually disable match hud
 setinfo cl_predict 1 // Force prediction on (https://github.com/ValveSoftware/Source-1-Games/issues/2618)
 voice_steal 2 // Force improved weapon sound channel heuristics
 snd_soundmixer Default_Mix // Fix freeze cam sound filter getting stuck

--- a/config/mastercomfig/cfg/comfig/game_overrides.cfg
+++ b/config/mastercomfig/cfg/comfig/game_overrides.cfg
@@ -1,7 +1,7 @@
 game_overrides // Run aliased game overrides
 game_overrides_c // Run custom aliased game overrides
 game_overrides_once // Run commands that should be run once
-alias block_game_overrides_once"alias game_overrides_once;match_hud_alias2";block_game_overrides_once // Block game_overrides_once and set match_hud_off to actually disable match hud
+alias block_game_overrides_once"alias game_overrides_once;match_hud_alias2";block_game_overrides_once // Block game_overrides_once and set match_hud_off to actually disable the match HUD
 setinfo cl_predict 1 // Force prediction on (https://github.com/ValveSoftware/Source-1-Games/issues/2618)
 voice_steal 2 // Force improved weapon sound channel heuristics
 snd_soundmixer Default_Mix // Fix freeze cam sound filter getting stuck


### PR DESCRIPTION
What this does is: after `match_hud_once` has been ran, `match_hud_off` will be set to `tf_use_match_hud 0`, instead of keep being set to `tf_use_match_hud 1;alias match_hud_once match_hud_disable`.

**Yes, the module already works, but it doesn't work like all modules. For example, `textures_very_high` will set textures to very high instantly, but `match_hud_off` will only set the match HUD to be disabled in the first load.**