### PR TITLE
Fix match_hud_off not working when run_modules has been used

### DIFF
--- a/config/mastercomfig/cfg/comfig/comfig.cfg
+++ b/config/mastercomfig/cfg/comfig/comfig.cfg
@@ -930,9 +930,9 @@ alias hud_panels_on"tf_healthicon_height_offset 10;tf_hud_target_id_offset 0"
 alias hud_panels hud_panels_on
 
 alias match_hud_alias"tf_use_match_hud 0"
-alias match_hud_alias2"alias match_hud_off match_hud_alias"
+alias match_hud_alias2"alias match_hud_off match_hud_alias;alias match_hud_alias3 match_hud_alias2"
 
-alias match_hud_off"tf_use_match_hud 1;alias match_hud_once match_hud_alias"
+alias match_hud_off"tf_use_match_hud 1;alias match_hud_once match_hud_alias;match_hud_alias3"
 alias match_hud_on"tf_use_match_hud 1;alias match_hud_once"
 
 alias match_hud match_hud_on


### PR DESCRIPTION
This fixes a rare case when someone uses run_modules but doesn't change classes, so `match_hud_alias2` will not be run again (since it is on `game_overrides.cfg`). But with this change, `match_hud_off` will always disable the match HUD if `match_hud_alias2` was ran before.