### PR TITLE
Removed command aliases

### DIFF
--- a/config/mastercomfig/cfg/comfig/comfig.cfg
+++ b/config/mastercomfig/cfg/comfig/comfig.cfg
@@ -31,33 +31,6 @@ hud_escort_interp .1 // Smooth out payload cart progress over slightly less time
 net_chokeloop 1 // Early check for multiplayer
 sv_lan 1 // Protect local servers
 
-// Directly forward string cmds to server for lower latency
-alias resetclass"cmd resetclass"
-alias menuopen"cmd menuopen"
-alias menuclosed"cmd menuclosed"
-alias stop_taunt"cmd stop_taunt"
-alias td_buyback"cmd td_buyback"
-alias arena_changeclass"cmd arena_changeclass"
-alias extendfreeze"cmd extendfreeze"
-alias show_motd"cmd show_motd"
-alias showroundinfo"cmd showroundinfo"
-alias autoteam"cmd autoteam"
-alias boo"cmd boo"
-alias done_viewing_loot"cmd done_viewing_loot"
-alias spectate"cmd spectate"
-alias status"cmd status"
-alias ping"cmd ping"
-alias pause"cmd pause"
-alias unpause"cmd unpause"
-alias demorestart"cmd demorestart"
-alias fade"cmd fade"
-alias nextmap"cmd nextmap"
-alias timeleft"cmd timeleft"
-alias ignoremsg"cmd ignoremsg"
-alias commentary_finishnode"cmd commentary_finishnode"
-alias kill"cmd kill"
-alias explode"cmd explode"
-
 // ------------------------------
 // '-- SourceTV Compatibility --'
 // ------------------------------

--- a/config/mastercomfig/cfg/comfig/comfig.cfg
+++ b/config/mastercomfig/cfg/comfig/comfig.cfg
@@ -31,6 +31,29 @@ hud_escort_interp .1 // Smooth out payload cart progress over slightly less time
 net_chokeloop 1 // Early check for multiplayer
 sv_lan 1 // Protect local servers
 
+// Directly forward string cmds to server for lower latency
+alias resetclass"cmd resetclass"
+alias menuopen"cmd menuopen"
+alias menuclosed"cmd menuclosed"
+alias stop_taunt"cmd stop_taunt"
+alias td_buyback"cmd td_buyback"
+alias arena_changeclass"cmd arena_changeclass"
+alias extendfreeze"cmd extendfreeze"
+alias show_motd"cmd show_motd"
+alias showroundinfo"cmd showroundinfo"
+alias autoteam"cmd autoteam"
+alias boo"cmd boo"
+alias done_viewing_loot"cmd done_viewing_loot"
+alias spectate"cmd spectate"
+alias demorestart"cmd demorestart"
+alias fade"cmd fade"
+alias nextmap"cmd nextmap"
+alias timeleft"cmd timeleft"
+alias ignoremsg"cmd ignoremsg"
+alias commentary_finishnode"cmd commentary_finishnode"
+alias kill"cmd kill"
+alias explode"cmd explode"
+
 // ------------------------------
 // '-- SourceTV Compatibility --'
 // ------------------------------


### PR DESCRIPTION
On a local server, these aliases cause any invocation of these commands result in a feedback loop, where every tick there are n + 1 invocations of that command being processed. This quickly causes the client to disconnect from the local server with "issued too many commands to server". If you increase the maximum number of commands per second before that check is hit, you will realize that all of these command are also broken on local servers (they are never actually processed). You just have a forever-increasing queue of commands building up, and if you look in net graph you will see an ever-increasing amount of network traffic.

ConCommands are stored in a hash map, which in practical terms means that searching through them happens in constant time, or O(1). On average, the time to look up any given command by name is going to be the same as any other command. So here, instead of spending your one unit of time looking up `explode`, for example, you spend your one unit of time looking up `cmd`. All this does is break local servers.