### PR TITLE
Add Medium-Low gibs module

### DIFF
--- a/config/mastercomfig/cfg/comfig/comfig.cfg
+++ b/config/mastercomfig/cfg/comfig/comfig.cfg
@@ -615,6 +615,7 @@ alias sillygibs
 
 alias gibs_off"cl_burninggibs 0;props_break_max_pieces 0;tf_playergib 0;sillygibs_on;sillygibs"
 alias gibs_low"cl_burninggibs 0;props_break_max_pieces 2;tf_playergib 1;sillygibs_off;sillygibs"
+alias gibs_medium_low"cl_burninggibs 0; props_break_max_pieces 4; tf_playergib 1;sillygibs_off;sillygibs"
 alias gibs_medium"cl_burninggibs 0;props_break_max_pieces -1;tf_playergib 1;sillygibs_off;sillygibs"
 alias gibs_high"cl_burninggibs 1;props_break_max_pieces -1;tf_playergib 1;sillygibs_off;sillygibs"
 
@@ -1589,6 +1590,7 @@ alias sprays=off"alias sprays sprays_off"
 alias sprays=on"alias sprays sprays_on"
 alias gibs=off"alias gibs gibs_off"
 alias gibs=low"alias gibs gibs_low"
+alias gibs=medium_low"alias gibs gibs_medium_low"
 alias gibs=medium"alias gibs gibs_medium"
 alias gibs=high"alias gibs gibs_high"
 alias sillygibs=auto"alias sillygibs"

--- a/config/mastercomfig/cfg/comfig/comfig.cfg
+++ b/config/mastercomfig/cfg/comfig/comfig.cfg
@@ -615,7 +615,7 @@ alias sillygibs
 
 alias gibs_off"cl_burninggibs 0;props_break_max_pieces 0;tf_playergib 0;sillygibs_on;sillygibs"
 alias gibs_low"cl_burninggibs 0;props_break_max_pieces 2;tf_playergib 1;sillygibs_off;sillygibs"
-alias gibs_medium_low"cl_burninggibs 0; props_break_max_pieces 4; tf_playergib 1;sillygibs_off;sillygibs"
+alias gibs_medium_low"cl_burninggibs 0;props_break_max_pieces 4;tf_playergib 1;sillygibs_off;sillygibs"
 alias gibs_medium"cl_burninggibs 0;props_break_max_pieces -1;tf_playergib 1;sillygibs_off;sillygibs"
 alias gibs_high"cl_burninggibs 1;props_break_max_pieces -1;tf_playergib 1;sillygibs_off;sillygibs"
 

--- a/config/templates/modules/modules.cfg
+++ b/config/templates/modules/modules.cfg
@@ -99,7 +99,7 @@
 // on, off
 
 //gibs=high
-// high, medium, low, off
+// high, medium, medium_low, low, off
 
 //sillygibs=auto
 // auto, on, off

--- a/data/modules.json
+++ b/data/modules.json
@@ -438,6 +438,9 @@
             "value": "low"
           },
           {
+            "value": "medium_low"
+          },
+          {
             "value": "medium"
           },
           {

--- a/docs/customization/modules.md
+++ b/docs/customization/modules.md
@@ -329,6 +329,7 @@ Default setting: based on which preset you are currently using.
 
 * **`gibs=off`**: Disables gibs.
 * **`gibs=low`**: Max of 2 gib parts.
+* **`gibs=medium_low`**: Max of 4 gib parts.
 * **`gibs=medium`**: Default number of gibs.
 * **`gibs=high`**: Default number of gibs, gibs can burn.
 


### PR DESCRIPTION
As pointed out by someone in our discord, the low module for gibs limits them to 2 pieces per object, and medium doesn't limit them at all. A quick check ingame shows that an exploding player can spawn anywhere between 9-12 gibs based on the class.

This Medium-Low module attempts to create a sweet spot between the two modules by limiting gibs to 4 per object.

The value of 4 gibs per object has little basis, and other values may fit better.

PR includes new module and it's addition to the docs.