### PR TITLE
Changed -gl_nv_bindless_texturing

### DIFF
--- a/docs/customization/launch_options.md
+++ b/docs/customization/launch_options.md
@@ -70,7 +70,7 @@ Read below about optional launch options and choosing your own DXLevel.
     * **-displayindex x** : uses the monitor at the specified display index. starts at `1`. `0` is the primary display (and the default)
     * **-gl_enablesamplerobjects** : enables OpenGL sampler objects :warning: **Experimental** as its performance impact (negative or positive) is unknown and its Source implementation may not be complete
     * **-gl_amd_pinned_memory** : uses `AMD_pinned_memory` for efficient device memory handling :warning: **Experimental** as its performance impact (negative or positive) is unknown
-    * **-gl_nv_bindless_texturing** : uses `NV_bindless_texture` for reduced overhead for managing bindings :warning: **Experimental** as its performance impact (negative or positive) is unknown and its Source implementation may not be complete
+    * **-gl_nv_bindless_texturing** : uses `NV_bindless_texture` for reduced overhead for managing bindings :warning: **Experimental** It seems to provide more stable performance at the cost of slightly reduced performance. (Requies further testing) Its Source implementation may not be complete
     * **-no_texture_stream** : disables texture streaming. Useful if you are on a powerful system not under video memory pressure.
 
 ## Uncommon Launch Options


### PR DESCRIPTION
I tested this using

Linux 64bit 5.8.5, Fedora 33
Ryzen 3 3200U
4G of RAM
SSD SATA

Used Medium Low with Lighting_Ex set to high due to seeing graphical errors using mat_phong 0.
mat_dxlevel 92 (OpenGL 3)

Conclusion after using 5 samples from both sides.
4812 frames 57.886 seconds 83.13 fps (12.03 ms/f) 10.753 fps variability
4812 frames 57.857 seconds 83.17 fps (12.02 ms/f) 10.696 fps variability
4812 frames 57.817 seconds 83.23 fps (12.02 ms/f) 11.097 fps variability
4812 frames 57.793 seconds 83.26 fps (12.01 ms/f) 10.886 fps variability
4812 frames 57.862 seconds 83.16 fps (12.02 ms/f) 10.807 fps variability
Bindless Texturing
83.19, 12.02, 10.8478

4812 frames 58.439 seconds 82.34 fps (12.14 ms/f) 11.761 fps variability
4812 frames 57.285 seconds 84.00 fps (11.90 ms/f) 11.149 fps variability
4812 frames 58.032 seconds 82.92 fps (12.06 ms/f) 10.993 fps variability
4812 frames 57.962 seconds 83.02 fps (12.05 ms/f) 10.726 fps variability
4812 frames 58.320 seconds 82.51 fps (12.12 ms/f) 10.794 fps variability
No bindless texturing
82.958, 12.054, 11.0846

On average the fps was more static across all tests with it enabled, without bindless texturing the performance was more variable but had higher potentials to reach better framerates, however on average -gl_nv_bindless_texturing was performing better. As far as I know there are no fps measurement tools on linux so I cannot test a 32 player pl_upward server nor any casual match, data from those would be eyeballed and likely inaccurate. I have no knowledge on how this performs with an intel CPU/GPU nor other combos, for now I'm leaving the tag as experimental with some benchmarks leaning towards it being a positive, I have plans of doing this same testing with -gl_amd_pinned_memory, then once that's complete combining them and seeing the result, if my testing needs more samples/is not capable of being accurate please let me know, from what I know about bindless texturing, it tends to be beneficial and in an artificial test that holds true.

I have no knowledge on if it's source implementation is or isn't complete but work does seem to be there based on the data.