### PR TITLE
#489 without decals changes

### DIFF
--- a/config/mastercomfig/cfg/comfig/comfig.cfg
+++ b/config/mastercomfig/cfg/comfig/comfig.cfg
@@ -800,7 +800,7 @@ mat_managedtextures 1 // Force enable managed textures
 // ---------------
 // Controls the highest frame rate (FPS/frames per second) that the game can reach.
 
-//mat_powersavingsmode 0 // Ensure power savings mode is disabled
+//mat_powersavingsmode 0 // Enable power savings mode. Useful for laptops.
 //fps_max 0 // Reaching the cap within a certain timing causes CPU intrinsic pauses
 //fps_max 1000 // A safety for users who can reach the max
 
@@ -942,9 +942,9 @@ alias hud_player_model_off"cl_hud_playerclass_use_playermodel 0"
 alias hud_player_model_on"cl_hud_playerclass_use_playermodel 1"
 
 alias dynamic_background_off
-alias dynamic_background_preload"map_background preload_room;wait 10;disconnect"
-alias dynamic_background_itemtest"map_background itemtest;wait 10;disconnect"
-alias dynamic_background_dustbowl"map_background background01;wait 1000;stop"
+alias dynamic_background_preload"sv_allow_wait_command 1;map_background preload_room;wait 10;disconnect"
+alias dynamic_background_itemtest"sv_allow_wait_command 1;map_background itemtest;wait 10;disconnect"
+alias dynamic_background_dustbowl"sv_allow_wait_command 1;map_background background01;wait 1000;stop"
 
 alias dynamic_background dynamic_background_off
 
@@ -979,9 +979,9 @@ cl_mute_all_comms 1 // Disable text and voice for muted players
 //cl_enable_text_chat 1 // Enable text chat
 tf_chat_popup_hold_time 3 // How long party messages appear on the main menu
 
-alias messages_on"hud_saytext_time 10;cl_enable_text_chat 1;cl_showtextmsg 1"
-alias messages_hide"hud_saytext_time 0;cl_enable_text_chat 1;cl_showtextmsg 1"
 alias messages_off"hud_saytext_time 0;cl_enable_text_chat 0;cl_showtextmsg 0"
+alias messages_hide"hud_saytext_time 0;cl_enable_text_chat 1;cl_showtextmsg 1
+alias messages_on"hud_saytext_time 10;cl_enable_text_chat 1;cl_showtextmsg 1"
 
 alias messages messages_on
 
@@ -1092,10 +1092,10 @@ alias hud_achievement hud_achievement_on
 //cl_show_num_particle_systems 1 // Show number of particle systems
 cl_mvm_wave_status_visible_during_wave 1 // MvM wave information during the wave
 
-alias debug_on"cl_showfps 2;cl_showpos 1;cl_showbattery 1;cl_show_num_particle_systems 1;developer 1;con_filter_enable 0;con_enable 1;net_graph 4"
-alias debug_on_partial"cl_showfps 1;cl_showpos 1;cl_showbattery 1;cl_show_num_particle_systems 0;developer 0;con_filter_enable 0;con_enable 1;net_graph 1"
-alias debug_minimal"cl_showfps 0;cl_showpos 0;cl_showbattery 0;cl_show_num_particle_systems 0;developer 0;con_filter_enable 0;con_enable 1;net_graph 0"
-alias debug_off"cl_showfps 0;cl_showpos 0;cl_showbattery 0;cl_show_num_particle_systems 0;developer 0;con_filter_text zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz;con_filter_enable 1;con_enable 0;net_graph 0"
+alias debug_off"cl_showfps 0;cl_showpos 0;cl_showbattery 0;cl_show_num_particle_systems 0;developer 0;net_graph 0;con_enable 0;con_filter_enable 1;con_filter_text zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz"
+alias debug_minimal"cl_showfps 0;cl_showpos 0;cl_showbattery 0;cl_show_num_particle_systems 0;developer 0;net_graph 0;con_enable 1;con_filter_enable 0"
+alias debug_on_partial"cl_showfps 0;cl_showpos 1;cl_showbattery 0;cl_show_num_particle_systems 0;developer 0;net_graph 1;con_enable 1;con_filter_enable 0"
+alias debug_on"cl_showfps 2;cl_showpos 1;cl_showbattery 1;cl_show_num_particle_systems 1;developer 1;net_graph 4;con_enable 1;con_filter_enable 0"
 
 alias debug debug_minimal
 
@@ -1494,9 +1494,9 @@ alias packet_rate=congestion"alias packet_rate packet_rate_congestion"
 alias packet_rate=standard"alias packet_rate packet_rate_standard"
 alias packet_rate=max"alias packet_rate packet_rate_max"
 alias snapshot_buffer=auto"alias snapshot_buffer"
-alias snapshot_buffer=high"alias snapshot_buffer snapshot_buffer_high"
-alias snapshot_buffer=safe"alias snapshot_buffer snapshot_buffer_safe"
 alias snapshot_buffer=low"alias snapshot_buffer snapshot_buffer_low"
+alias snapshot_buffer=safe"alias snapshot_buffer snapshot_buffer_safe"
+alias snapshot_buffer=high"alias snapshot_buffer snapshot_buffer_high"
 alias packet_size=small"alias packet_size packet_size_small"
 alias packet_size=conservative"alias packet_size packet_size_conservative"
 alias packet_size=big"alias packet_size packet_size_big"
@@ -1647,22 +1647,18 @@ alias fpscap=300"alias fpscap fpscap_300"
 alias fpscap=360"alias fpscap fpscap_360"
 alias fpscap=400"alias fpscap fpscap_400"
 alias fpscap=1000"alias fpscap fpscap_1000"
+alias fpscap=unlimited"alias fpscap fpscap_unlimited"
 alias opengl=skip"alias opengl"
 alias opengl=default"alias opengl opengl_default"
-alias fpscap=unlimited"alias fpscap fpscap_unlimited"
 alias hud_player_model=off"alias hud_player_model hud_player_model_off"
 alias hud_player_model=on"alias hud_player_model hud_player_model_on"
-alias match_hud=off"alias match_hud match_hud_off"
-alias match_hud=on"alias match_hud match_hud_on"
 alias hud_panels=off"alias hud_panels hud_panels_off"
 alias hud_panels=on"alias hud_panels hud_panels_on"
-alias dynamic_background=off"alias dynamic_background dynamic_background_off"
-alias dynamic_background=preload"alias dynamic_background dynamic_background_preload"
-alias dynamic_background=itemtest"alias dynamic_background dynamic_background_itemtest"
-alias dynamic_background=dustbowl"alias dynamic_background dynamic_background_dustbowl"
-alias messages=on"alias messages messages_on"
-alias messages=hide"alias messages messages_hide"
+alias match_hud=off"alias match_hud match_hud_off"
+alias match_hud=on"alias match_hud match_hud_on"
 alias messages=off"alias messages messages_off"
+alias messages=hide"alias messages messages_hide"
+alias messages=on"alias messages messages_on"
 alias killfeed=off"alias killfeed killfeed_off"
 alias killfeed=on"alias killfeed killfeed_on"
 alias killstreaks=off"alias killstreaks killstreaks_off"
@@ -1670,16 +1666,18 @@ alias killstreaks=low"alias killstreaks killstreaks_low"
 alias killstreaks=high"alias killstreaks killstreaks_high"
 alias hud_achievement=off"alias hud_achievement hud_achievement_off"
 alias hud_achievement=on"alias hud_achievement hud_achievement_on"
-alias debug=on"alias debug debug_on"
-alias debug=on_partial"alias debug debug_on_partial"
-alias debug=minimal"alias debug debug_minimal"
 alias debug=off"alias debug debug_off"
+alias debug=minimal"alias debug debug_minimal"
+alias debug=on_partial"alias debug debug_on_partial"
+alias debug=on"alias debug debug_on"
 alias outlines=off"alias outlines outlines_off"
 alias outlines=low"alias outlines outlines_low"
 alias outlines=medium"alias outlines outlines_medium"
 alias outlines=high"alias outlines outlines_high"
-alias mod_support=off"alias mod_support mod_support_off"
-alias mod_support=on"alias mod_support mod_support_on"
+alias dynamic_background=off"alias dynamic_background dynamic_background_off"
+alias dynamic_background=preload"alias dynamic_background dynamic_background_preload"
+alias dynamic_background=itemtest"alias dynamic_background dynamic_background_itemtest"
+alias dynamic_background=dustbowl"alias dynamic_background dynamic_background_dustbowl"
 alias sound=low"alias sound sound_low"
 alias sound=medium"alias sound sound_medium"
 alias sound=high"alias sound sound_high"
@@ -1687,11 +1685,13 @@ alias sound=very_high"alias sound sound_very_high"
 alias sound=ultra"alias sound sound_ultra"
 alias voice_chat=off"alias voice_chat voice_chat_off"
 alias voice_chat=on"alias voice_chat voice_chat_on"
-alias logo=off"alias logo logo_off"
-alias logo=on"alias logo logo_on"
+alias mod_support=off"alias mod_support mod_support_off"
+alias mod_support=on"alias mod_support mod_support_on"
 alias party_mode=open"alias party_mode party_mode_open"
 alias party_mode=request"alias party_mode party_mode_request"
 alias party_mode=invite"alias party_mode party_mode_invite"
+alias logo=off"alias logo logo_off"
+alias logo=on"alias logo logo_on"
 
 // ---------------------------------
 // '-- User-Overrideable Aliases --'

--- a/docs/customization/modules.md
+++ b/docs/customization/modules.md
@@ -557,7 +557,7 @@ Default setting: **`debug=minimal`** (all presets, except Very Low).
 
 * **`debug=off`**: Disables all debug features.
 * **`debug=minimal`**: Enables developer console.
-* **`debug=on_partial`**: Enables developer console and cl_showpos.
+* **`debug=on_partial`**: Enables developer console, position graph (`cl_showpos 1`) and net graph (`net_graph 1`).
 * **`debug=on`**: Enables all debug HUDs.
 
 ### Outlines

--- a/docs/customization/modules.md
+++ b/docs/customization/modules.md
@@ -557,7 +557,7 @@ Default setting: **`debug=minimal`** (all presets, except Very Low).
 
 * **`debug=off`**: Disables all debug features.
 * **`debug=minimal`**: Enables developer console.
-* **`debug=on_partial`**: Enables all but the noisiest debug HUDs.
+* **`debug=on_partial`**: Enables developer console and cl_showpos.
 * **`debug=on`**: Enables all debug HUDs.
 
 ### Outlines

--- a/docs/next_steps/troubleshoot.md
+++ b/docs/next_steps/troubleshoot.md
@@ -98,7 +98,7 @@ Ignore these, as these happen in a clean TF2 installation and only Valve can fix
 
 ## "Unknown command gl_\*" errors in console
 
-mastercomfig sets some OpenGL-related cvars, which are only available on Linux and macOS. Thus, these errors appear a few times when using mastercomfig on Windows. These errors are harmless and can be ignored safely. However, you can disable running the commands by putting `opengl=skip` into your `modules.cfg`.
+mastercomfig sets some OpenGL-related cvars, which are only available on Linux and macOS. These errors are harmless and can be ignored safely. However, you can disable running the commands by putting `opengl=skip` into your `modules.cfg`.
 
 ## I want another interp value
 


### PR DESCRIPTION
Justifications for each change:

**comfig.cfg**

- `mat_powersavingsmode`: the comment isn't explaining what it really does. The current comment was added by me when mat_powersavingsmode was in the Optimizations section. It had the same idea as the `mat_vsync` comment (`mat_vsync 0 // Ensure VSync is disabled`).

- `dynamic_background`: I added `sv_allow_wait_command 1` to it because I thought that in the future someone would say "hey my map background isn't loading whatdoido helpmepls" so here is the preventive solution.

- `debug_on_partial`: I changed it so it only enables the developer console, net_graph 1 and cl_showpos 1.

- The rest of the changes are purely cosmetic. Most of them were made to align with the docs.

**modules.md**

- Changed the explanation for `debug=on_partial`.

**troubleshoot.md**

- The OpenGL errors don't appear only a few times when using Windows, they always appear in the console after loading the game, so I removed this part of the troubleshoot.

That's all.