### PR TITLE
Remove mp_respawnwavetime from debug

### DIFF
--- a/config/mastercomfig/cfg/comfig/comfig.cfg
+++ b/config/mastercomfig/cfg/comfig/comfig.cfg
@@ -1123,7 +1123,7 @@ alias switchconsole console_on_flip
 
 alias debug_output"developer 1"
 
-alias debug_instant_respawn"sv_cheats 1;mp_disable_respawn_times 1;spec_freeze_time 0;spec_freeze_traveltime 0;mp_respawnwavetime 0"
+alias debug_instant_respawn"sv_cheats 1;mp_disable_respawn_times 1;spec_freeze_time 0;spec_freeze_traveltime .01"
 alias debug_invulernable"sv_cheats 1;buddha"
 
 alias debug_bots"tf_bot_quota 32"


### PR DESCRIPTION
It does nothing and `spec_freeze_traveltime`'s minimum value is `0.01`.