### PR TITLE
Changed debug_output to toggle developer cvar

### DIFF
--- a/config/mastercomfig/cfg/comfig/comfig.cfg
+++ b/config/mastercomfig/cfg/comfig/comfig.cfg
@@ -1174,7 +1174,12 @@ alias switchconsole console_on_flip
 // -------------
 // Some handy commands for debugging the game.
 
-alias debug_output"incrementvar developer 0 1 1"
+alias debug_output"debug_output_1"
+alias debug_output_toggle"incrementvar developer 0 4 1"
+alias debug_output_1"developer 1"
+alias debug_output_2"developer 2"
+alias debug_output_3"developer 3"
+alias debug_output_4"developer 4"
 
 alias debug_instant_respawn"sv_cheats 1;mp_disable_respawn_times 1;spec_freeze_time 0;spec_freeze_traveltime 0;mp_respawnwavetime 0"
 alias debug_invulernable"sv_cheats 1;buddha"

--- a/config/mastercomfig/cfg/comfig/comfig.cfg
+++ b/config/mastercomfig/cfg/comfig/comfig.cfg
@@ -1174,7 +1174,7 @@ alias switchconsole console_on_flip
 // -------------
 // Some handy commands for debugging the game.
 
-alias debug_output"developer 1"
+alias debug_output"incrementvar developer 0 1 1"
 
 alias debug_instant_respawn"sv_cheats 1;mp_disable_respawn_times 1;spec_freeze_time 0;spec_freeze_traveltime 0;mp_respawnwavetime 0"
 alias debug_invulernable"sv_cheats 1;buddha"


### PR DESCRIPTION
Tiny PR but it's my first so fuck it.

All this changes is the `debug_output` command which currently sets `developer` to 1.

This changes that to toggle it instead, so running `debug_output` twice would toggle it from 0 to 1 to 0 etc.