### PR TITLE
Remove launch options deleted in September 16 update

### DIFF
--- a/docs/tf2/launchopts_win.md
+++ b/docs/tf2/launchopts_win.md
@@ -110,7 +110,6 @@ description: A list of all launch options on TF2 for Windows.
 -noforcemaccel
 -noforcemspd
 -nogamedll
--nogamestats
 -noglslcontrolflow
 -nohltv
 -NOINITMEMORY
@@ -145,7 +144,6 @@ description: A list of all launch options on TF2 for Windows.
 -outdir
 -p4
 -particles
--phonehome
 -pidfile
 -pixel_offset_x
 -pixel_offset_y
@@ -159,7 +157,6 @@ description: A list of all launch options on TF2 for Windows.
 -PROCESSHEAP
 -PROCESSHEAPZEROMEM
 -profile
--publicbuild
 -quickswitch
 -quiet
 -raiseonassert
@@ -230,7 +227,6 @@ description: A list of all launch options on TF2 for Windows.
 -usercon
 -usereslistfile
 -UseStandardError
--usetcp
 -vcrplayback
 -vcrrecord
 -vguifocus


### PR DESCRIPTION
These 4 launch options were removed in the September 16th update.

these either never existed in the linux version, or the linux launch option page on the docs is outdated.