### PR TITLE
Add a quick-fix for removing the dxlevle flag

### DIFF
--- a/docs/next_steps/quick_fixes.md
+++ b/docs/next_steps/quick_fixes.md
@@ -139,8 +139,6 @@ Run `very_low_reset` on the console. It will reset the remaining settings that w
 
 Please note that running this may reset some personal preferences back to default.
 
-
 ## Game resolution keeps resetting.
 
 Check to see if you have `-dxlevel 100` in your TF2 launch options, it should hmay have a different number next to it. You only needed this one time.
-

--- a/docs/next_steps/quick_fixes.md
+++ b/docs/next_steps/quick_fixes.md
@@ -139,3 +139,8 @@ Run `very_low_reset` on the console. It will reset the remaining settings that w
 
 Please note that running this may reset some personal preferences back to default.
 
+
+## Game resolution keeps resetting.
+
+Check to see if you have `-dxlevel 100` in your TF2 launch options, it should hmay have a different number next to it. You only needed this one time.
+


### PR DESCRIPTION
I reinstalled my TF2 and forgot to remove my -dxlevel flag. This kept resetting my resolution settings. Had to hop into the discord to ask why. Turns out it was just me being absent minded. Figured if anyone else had this issue a small addition to the quick-fixes wouldn't hurt.