### PR TITLE
Config updates

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -163,10 +163,10 @@ the existing modules if applicable, then add documentation for it at the
 
 The first part of adding modules is a multi-step process in `config/mastercomfig/cfg/comfig/comfig.cfg`:
 
-* Add the module level alias(es) (`alias module_level "cvar1 1; cvar2 0`)
+* Add the module level alias(es) (`alias module_level "cvar1 1;cvar2 0`).
   * For every command in the module, all levels must set that command unless there is no impact at that level.
-* Add the set module level alias(es) (`alias module=level"alias module module_level"`)
-* Possibly adjust presets in  `config/cfg/presets` to use the new module or levels to an existing module
+* Add the set module level alias(es) (`alias module=level"alias module module_level"`).
+* Possibly adjust presets in `config/cfg/presets` to use the new module or levels to an existing module.
 
 If you are adding a new module, you will also need to add a new `module` entry in `config/mastercomfig/cfg/comfig/modules_run.cfg`
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -163,8 +163,7 @@ the existing modules if applicable, then add documentation for it at the
 
 The first part of adding modules is a multi-step process in `config/mastercomfig/cfg/comfig/comfig.cfg`:
 
-* Add the module level alias(es) (`alias module_level "cvar1 1;cvar2 0`).
-  * For every command in the module, all levels must set that command unless there is no impact at that level.
+* Add the module level alias(es) (`alias module_level "cvar1 1;cvar2 0`). For every command in the module, all levels must set that command unless there is no impact at that level.
 * Add the set module level alias(es) (`alias module=level"alias module module_level"`).
 * Possibly adjust presets in `config/cfg/presets` to use the new module or levels to an existing module.
 

--- a/config/mastercomfig/cfg/comfig/comfig.cfg
+++ b/config/mastercomfig/cfg/comfig/comfig.cfg
@@ -35,32 +35,32 @@ cl_localnetworkbackdoor 0 // Fast path to skip backdoor
 host_limitlocal 1 // Prevent excess work on local
 
 // Directly forward string cmds to server for lower latency
- alias resetclass"cmd resetclass"
- alias menuopen"cmd menuopen"
- alias menuclosed"cmd menuclosed"
- alias stop_taunt"cmd stop_taunt"
- alias td_buyback"cmd td_buyback"
- alias arena_changeclass"cmd arena_changeclass"
- alias extendfreeze"cmd extendfreeze"
- alias show_motd"cmd show_motd"
- alias showroundinfo"cmd showroundinfo"
- alias autoteam"cmd autoteam"
- alias boo"cmd boo"
- alias done_viewing_loot"cmd done_viewing_loot"
- alias spectate"cmd spectate"
- alias demorestart"cmd demorestart"
- alias fade"cmd fade"
- alias nextmap"cmd nextmap"
- alias timeleft"cmd timeleft"
- alias ignoremsg"cmd ignoremsg"
- alias commentary_finishnode"cmd commentary_finishnode"
- alias kill"cmd kill"
- alias explode"cmd explode"
+alias resetclass"cmd resetclass"
+alias menuopen"cmd menuopen"
+alias menuclosed"cmd menuclosed"
+alias stop_taunt"cmd stop_taunt"
+alias td_buyback"cmd td_buyback"
+alias arena_changeclass"cmd arena_changeclass"
+alias extendfreeze"cmd extendfreeze"
+alias show_motd"cmd show_motd"
+alias showroundinfo"cmd showroundinfo"
+alias autoteam"cmd autoteam"
+alias boo"cmd boo"
+alias done_viewing_loot"cmd done_viewing_loot"
+alias spectate"cmd spectate"
+alias demorestart"cmd demorestart"
+alias fade"cmd fade"
+alias nextmap"cmd nextmap"
+alias timeleft"cmd timeleft"
+alias ignoremsg"cmd ignoremsg"
+alias commentary_finishnode"cmd commentary_finishnode"
+alias kill"cmd kill"
+alias explode"cmd explode"
 
 // ------------------------------
 // '-- SourceTV Compatibility --'
 // ------------------------------
-// Optimize spectator view, or ensures compatibility with SourceTV.
+// Optimize spectator view, or ensures compatibility with SourceTV
 
 //alias spec_next cmd spec_next;alias spec_prev cmd spec_prev // Optimize spectator view switching, but does not work with SourceTV
 
@@ -139,7 +139,7 @@ alias packet_size packet_size_speed
 
 net_maxcleartime 0 // No need to check for our limit, since cmdrate is the bound
 //rate 196608 // Rate used for server communication, delays packets based on this value and packet size
-net_splitpacket_maxrate 131072 // Lower split packet rate to make sure they are transmitted properly
+net_splitpacket_maxrate 131072 // Max split packet rate
 //net_splitpacket_maxrate 1048576 // Use rate as bound for split packets
 
 alias bandwidth_128Kbps"rate 16000;alias bandwidth_level echo bandwidth=128Kbps"
@@ -898,7 +898,7 @@ alias mm_queue_party"quit smoking"
 // ---------------
 // Controls the highest frame rate (FPS/frames per second) that the game can reach
 
-//mat_powersavingsmode 1 // Set the FPS cap to half of refresh rate.
+//mat_powersavingsmode 1 // Set the FPS cap to half of refresh rate
 //fps_max 0 // Reaching the cap within a certain timing causes CPU intrinsic pauses
 //fps_max 1000 // A safety for users who can reach the max
 
@@ -1142,7 +1142,7 @@ tf_backpack_page_button_delay .25 // Decrease button delay for moving items
 // -------------------
 // Killstreak messages from weapons
 
-//cl_hud_killstreak_display_alpha 100 // Adjust the translucency of the killstreak banner (0 to 255)
+//cl_hud_killstreak_display_alpha 120 // Adjust the translucency of the killstreak banner (0 to 255)
 //cl_hud_killstreak_display_alpha 255 // Disable transparency
 //cl_hud_killstreak_display_fontsize 0 // Killstreak font size (0 to 2)
 //cl_hud_killstreak_display_time 2 // Killstreak display time in seconds
@@ -1150,7 +1150,7 @@ tf_backpack_page_button_delay .25 // Decrease button delay for moving items
 
 alias killstreaks_off"cl_hud_killstreak_display_time 0;alias killstreaks_level echo killstreaks=off"
 alias killstreaks_low"cl_hud_killstreak_display_alpha 255;cl_hud_killstreak_display_time 2;alias killstreaks_level echo killstreaks=low"
-alias killstreaks_high"cl_hud_killstreak_display_alpha 100;cl_hud_killstreak_display_time 2;alias killstreaks_level echo killstreaks=high"
+alias killstreaks_high"cl_hud_killstreak_display_alpha 120;cl_hud_killstreak_display_time 2;alias killstreaks_level echo killstreaks=high"
 
 alias killstreaks killstreaks_high
 
@@ -1184,6 +1184,7 @@ cl_vote_ui_active_after_voting 1 // Keep the vote UI active after voting to see 
                                  // 1 - all
                                  // 2 - active only
 
+alias hud_contracts_auto"alias hud_contracts_level echo hud_contracts=auto"
 alias hud_contracts_hide"tf_contract_competitive_show 0;tf_contract_progress_show 0;alias hud_contracts_level echo hud_contracts=hide"
 alias hud_contracts_all"tf_contract_competitive_show 1;tf_contract_progress_show 1;alias hud_contracts_level echo hud_contracts=all"
 alias hud_contracts_active"tf_contract_competitive_show 2;tf_contract_progress_show 2;alias hud_contracts_level echo hud_contracts=active"
@@ -1230,59 +1231,59 @@ cl_mvm_wave_status_visible_during_wave 1 // MvM wave information during the wave
 //con_nprint_bgalpha 0 // Disable drawing box around nprint
 //con_drawnotify 1 // Draw notification area (for taking screenshots)
 
- alias console_off"con_filter_text zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz;con_filter_enable 1;con_enable 0;alias console_level echo console=off"
- alias console_on"con_filter_enable 0;con_enable 1;alias console_level echo console=on"
+alias console_off"con_filter_text zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz;con_filter_enable 1;con_enable 0;alias console_level echo console=off"
+alias console_on"con_filter_enable 0;con_enable 1;alias console_level echo console=on"
 
- alias console console_on
+alias console console_on
 
- alias console_off_flip"hideconsole;console_off;alias switchconsole console_on_flip"
- alias console_on_flip"console_on;showconsole;alias switchconsole console_off_flip"
+alias console_off_flip"hideconsole;console_off;alias switchconsole console_on_flip"
+alias console_on_flip"console_on;showconsole;alias switchconsole console_off_flip"
 
 // switchconsole bind for turning off console while it is not visible
- alias switchconsole console_on_flip
+alias switchconsole console_on_flip
 
 // -------------
 // '-- Debug --'
 // -------------
 // Some handy commands for debugging the game
 
- alias debug_output"debug_output_1"
- alias debug_output_toggle"incrementvar developer -1 2 1"
- alias debug_output_display"developer -1"
- alias debug_output_1"developer 1"
- alias debug_output_2"developer 2"
+alias debug_output"debug_output_1"
+alias debug_output_toggle"incrementvar developer -1 2 1"
+alias debug_output_display"developer -1"
+alias debug_output_1"developer 1"
+alias debug_output_2"developer 2"
  
- alias debug_instant_respawn"sv_cheats 1;mp_disable_respawn_times 1;spec_freeze_time 0;spec_freeze_traveltime 0;mp_respawnwavetime 0"
- alias debug_invulnerable"sv_cheats 1;buddha"
+alias debug_instant_respawn"sv_cheats 1;mp_disable_respawn_times 1;spec_freeze_time 0;spec_freeze_traveltime 0;mp_respawnwavetime 0"
+alias debug_invulnerable"sv_cheats 1;buddha"
 
- alias debug_bots"tf_bot_kick all;tf_bot_quota_mode normal;tf_bot_difficulty 3;tf_bot_quota 32"
- alias debug_target"sv_cheats 1;bot -targetdummy"
+alias debug_bots"tf_bot_kick all;tf_bot_quota_mode normal;tf_bot_difficulty 3;tf_bot_quota 32"
+alias debug_target"sv_cheats 1;bot -targetdummy"
 
- alias debug_occlusion"sv_cheats 1;r_visocclusion 1;r_occlusionspew 1"
- alias debug_pixelvis"r_drawpixelvisibility 1;r_pixelvisibility_spew 1"
- alias debug_fillrate"sv_cheats 1;mat_fillrate 1"
- alias debug_matsys_reload"toggle mat_aaquality"
+alias debug_occlusion"sv_cheats 1;r_visocclusion 1;r_occlusionspew 1"
+alias debug_pixelvis"r_drawpixelvisibility 1;r_pixelvisibility_spew 1"
+alias debug_fillrate"sv_cheats 1;mat_fillrate 1"
+alias debug_matsys_reload"toggle mat_aaquality"
 
- alias debug_sound_loads"snd_async_showmem;snd_async_spew 1;snd_async_spew_blocking 2;snd_async_stream_spew 2"
- alias debug_sound_dsp"sv_cheats 1;snd_showstart 2;adsp_debug 6"
+alias debug_sound_loads"snd_async_showmem;snd_async_spew 1;snd_async_spew_blocking 2;snd_async_stream_spew 2"
+alias debug_sound_dsp"sv_cheats 1;snd_showstart 2;adsp_debug 6"
 
- alias debug_network_packets"net_showudp 1"
- alias debug_network_drops"net_showdrop 1"
- alias debug_network_graph"net_graph 4"
- alias debug_network_pred"cl_showerror 2"
+alias debug_network_packets"net_showudp 1"
+alias debug_network_drops"net_showdrop 1"
+alias debug_network_graph"net_graph 4"
+alias debug_network_pred"cl_showerror 2"
 
- alias debug_fps"net_graph 1"
- alias debug_fps_range"cl_showfps 0;cl_showfps 2"
+alias debug_fps"net_graph 1"
+alias debug_fps_range"cl_showfps 0;cl_showfps 2"
 
- alias debug_vprof_log_spike"con_logfile vprof_spike.log"
- alias debug_vprof_log"con_logfile vprof.log"
+alias debug_vprof_log_spike"con_logfile vprof_spike.log"
+alias debug_vprof_log"con_logfile vprof.log"
 
- alias debug_vprof_spike"vprof_dump_spikes 100"
+alias debug_vprof_spike"vprof_dump_spikes 100"
 
- alias debug_vprof_spikes"vprof_off;vprof_reset;debug_vprof_log_spike;vprof_dump_oninterval 0;vprof_report_oninterval 0;debug_vprof_spike;vprof_on"
- alias debug_vprof_dump"vprof_off;vprof_reset;debug_vprof_log;vprof_dump_oninterval 10;vprof_report_oninterval 0;vprof_dump_spikes 0;vprof_on"
- alias debug_vprof_report"vprof_off;vprof_reset;debug_vprof_log;vprof_dump_oninterval 0;vprof_report_oninterval 10;vprof_dump_spikes 0;vprof_on"
- alias debug_vprof_off"vprof_off;vprof_reset;con_logfile 0;vprof_dump_oninterval 0;vprof_report_oninterval 0;vprof_dump_spikes 0"
+alias debug_vprof_spikes"vprof_off;vprof_reset;debug_vprof_log_spike;vprof_dump_oninterval 0;vprof_report_oninterval 0;debug_vprof_spike;vprof_on"
+alias debug_vprof_dump"vprof_off;vprof_reset;debug_vprof_log;vprof_dump_oninterval 10;vprof_report_oninterval 0;vprof_dump_spikes 0;vprof_on"
+alias debug_vprof_report"vprof_off;vprof_reset;debug_vprof_log;vprof_dump_oninterval 0;vprof_report_oninterval 10;vprof_dump_spikes 0;vprof_on"
+alias debug_vprof_off"vprof_off;vprof_reset;con_logfile 0;vprof_dump_oninterval 0;vprof_report_oninterval 0;vprof_dump_spikes 0"
 
 // -----------------------
 // '-- Closed Captions --'
@@ -1677,8 +1678,8 @@ alias packet_size=speed"alias packet_size packet_size_speed"
 alias bandwidth=128Kbps"alias bandwidth bandwidth_128Kbps"
 alias bandwidth=192Kbps"alias bandwidth bandwidth_192Kbps"
 alias bandwidth=384Kbps"alias bandwidth bandwidth_384Kbps"
-alias bandwidth=0.5Mbps"alias bandwidth bandwidth_0.5Mbps"
-alias bandwidth=0.8Mbps"alias bandwidth bandwidth_0.8Mbps"
+alias bandwidth=512Kbps"alias bandwidth bandwidth_512Kbps"
+alias bandwidth=762Kbps"alias bandwidth bandwidth_762Kbps"
 alias bandwidth=1.0Mbps"alias bandwidth bandwidth_1.0Mbps"
 alias bandwidth=1.5Mbps"alias bandwidth bandwidth_1.5Mbps"
 alias bandwidth=2.0Mbps"alias bandwidth bandwidth_2.0Mbps"
@@ -1829,6 +1830,7 @@ alias vsync=off"alias vsync vsync_off"
 alias vsync=on"alias vsync vsync_on"
 alias hud_player_model=off"alias hud_player_model hud_player_model_off"
 alias hud_player_model=on"alias hud_player_model hud_player_model_on"
+alias hud_contracts=auto"alias hud_contracts hud_contracts_auto"
 alias hud_contracts=hide"alias hud_contracts hud_contracts_hide"
 alias hud_contracts=all"alias hud_contracts hud_contracts_all"
 alias hud_contracts=active"alias hud_contracts hud_contracts_active"

--- a/config/mastercomfig/cfg/comfig/comfig.cfg
+++ b/config/mastercomfig/cfg/comfig/comfig.cfg
@@ -1252,7 +1252,7 @@ alias debug_output_toggle"incrementvar developer -1 2 1"
 alias debug_output_display"developer -1"
 alias debug_output_1"developer 1"
 alias debug_output_2"developer 2"
- 
+
 alias debug_instant_respawn"sv_cheats 1;mp_disable_respawn_times 1;spec_freeze_time 0;spec_freeze_traveltime 0;mp_respawnwavetime 0"
 alias debug_invulnerable"sv_cheats 1;buddha"
 

--- a/config/templates/config/config_template.cfg
+++ b/config/templates/config/config_template.cfg
@@ -94,7 +94,7 @@ net_maxroutable 1200;net_maxfragments 1200 // Use max recommended packet size by
 
 net_maxcleartime 0 // No need to check for our limit, since cmdrate is the bound
 //rate 196608 // Rate used for server communication, delays packets based on this value and packet size
-net_splitpacket_maxrate 131072 // Lower split packet rate to make sure they are transmitted properly
+net_splitpacket_maxrate 131072 // Max split packet rate
 //net_splitpacket_maxrate 1048576 // Use rate as bound for split packets
 
 rate 131072 // 1.0Mbps game bandwidth
@@ -585,7 +585,7 @@ mat_queue_mode -1 // Make sure ideal threading mode is on
 // ---------------
 // Controls the highest frame rate (FPS/frames per second) that the game can reach
 
-//mat_powersavingsmode 1 // Set the FPS cap to half of refresh rate.
+//mat_powersavingsmode 1 // Set the FPS cap to half of refresh rate
 //fps_max 0 // Reaching the cap within a certain timing causes CPU intrinsic pauses
 fps_max 1000 // A safety for users who can reach the max
 
@@ -757,7 +757,7 @@ tf_backpack_page_button_delay .25 // Decrease button delay for moving items
 // -------------------
 // Killstreak messages from weapons
 
-//cl_hud_killstreak_display_alpha 100 // Adjust the translucency of the killstreak banner (0 to 255)
+//cl_hud_killstreak_display_alpha 120 // Adjust the translucency of the killstreak banner (0 to 255)
 //cl_hud_killstreak_display_alpha 255 // Disable transparency
 //cl_hud_killstreak_display_fontsize 0 // Killstreak font size (0 to 2)
 //cl_hud_killstreak_display_time 2 // Killstreak display time in seconds
@@ -803,7 +803,7 @@ cl_vote_ui_active_after_voting 1 // Keep the vote UI active after voting to see 
 //hud_achievement_tracker 1 // Enable achievement tracker
 //hud_achievement_count 8 // Max achievements shown on HUD
 //hud_achievement_count_engineer 3 // Max achievements shown on HUD when playing as Engineer
-hud_achievement_description 0;hud_achievement_tracker 0;hud_achievement_count 0;hud_achievement_count_engineer 0;hud_achievement_glowtime 0 // Disable HUD tracking
+//hud_achievement_description 0;hud_achievement_tracker 0;hud_achievement_count 0;hud_achievement_count_engineer 0;hud_achievement_glowtime 0 // Disable HUD tracking
 
 // ------------
 // '-- Info --'

--- a/config/templates/modules/modules.cfg
+++ b/config/templates/modules/modules.cfg
@@ -147,8 +147,8 @@
 //hud_player_model=on
 // on, off
 
-//hud_contracts=all
-// active, all, hide
+//hud_contracts=auto
+// active, all, hide, auto
 
 //hud_panels=high
 // high, low, off

--- a/data/modules.json
+++ b/data/modules.json
@@ -666,6 +666,9 @@
         "display": "Contracts",
         "values": [
           {
+            "value": "auto"
+          },
+          {
             "value": "hide",
             "display": "Hide Contracts"
           },

--- a/data/preset_modules.json
+++ b/data/preset_modules.json
@@ -231,7 +231,7 @@
     "none": ""
   },
   "hud_contracts": {
-    "default": "",
+    "default": "auto",
     "very-low": "off"
   },
   "hud_panels": {

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -167,10 +167,10 @@ the existing modules if applicable, then add documentation for it at the
 
 The first part of adding modules is a multi-step process in `config/mastercomfig/cfg/comfig/comfig.cfg`:
 
-* Add the module level alias(es) (`alias module_level "cvar1 1; cvar2 0`)
+* Add the module level alias(es) (`alias module_level "cvar1 1;cvar2 0`).
   * For every command in the module, all levels must set that command unless there is no impact at that level.
-* Add the set module level alias(es) (`alias module=level"alias module module_level"`)
-* Possibly adjust presets in  `config/cfg/presets` to use the new module or levels to an existing module
+* Add the set module level alias(es) (`alias module=level"alias module module_level"`).
+* Possibly adjust presets in `config/cfg/presets` to use the new module or levels to an existing module.
 
 If you are adding a new module, you will also need to add a new `module` entry in `config/mastercomfig/cfg/comfig/modules_run.cfg`
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -167,8 +167,7 @@ the existing modules if applicable, then add documentation for it at the
 
 The first part of adding modules is a multi-step process in `config/mastercomfig/cfg/comfig/comfig.cfg`:
 
-* Add the module level alias(es) (`alias module_level "cvar1 1;cvar2 0`).
-  * For every command in the module, all levels must set that command unless there is no impact at that level.
+* Add the module level alias(es) (`alias module_level "cvar1 1;cvar2 0`). For every command in the module, all levels must set that command unless there is no impact at that level.
 * Add the set module level alias(es) (`alias module=level"alias module module_level"`).
 * Possibly adjust presets in `config/cfg/presets` to use the new module or levels to an existing module.
 

--- a/docs/customization/modules.md
+++ b/docs/customization/modules.md
@@ -148,7 +148,7 @@ Filters what custom content is allowed to be downloaded from the server.
 
 Default setting: **`download=auto`** (all presets).
 
-* **`download=auto`**: Whatever the user set in the game settings. By default, the game downloads all custom files from servers.
+* **`download=auto`**: Whatever the user set in the game settings.
 * **`download=all`**: Download all custom files from servers.
 * **`download=nosounds`**: Download everything but sounds from servers.
 * **`download=mapsonly`**: Download only maps from servers.
@@ -536,6 +536,9 @@ Default setting: **`sheens_speed=slow`** (all presets, except Very Low).
 
 Controls how intense the color tint is on the killstreak sheen glow for weapons.
 
+!!! warning
+    This module will have no effect if you have `sheens_speed` set to `off`.
+
 * **CPU usage:** none
 * **GPU usage:** none
 
@@ -659,8 +662,9 @@ Controls the Contracts HUD seen at the top right corner of the screen during gam
 * **CPU usage:** low
 * **GPU usage:** none
 
-Default setting: unset (all presets, except Very Low)
+Default setting: **`hud_contracts=auto`** (all presets, except Very Low).
 
+* **`hud_contracts=auto`**: Whatever the user set in the game settings.
 * **`hud_contracts=hide`**: Hides the Contracts HUD.
 * **`hud_contracts=all`**: Shows all Contracts available.
 * **`hud_contracts=active`**: Only shows active Contracts.

--- a/docs/customization/modules.md
+++ b/docs/customization/modules.md
@@ -537,7 +537,7 @@ Default setting: **`sheens_speed=slow`** (all presets, except Very Low).
 Controls how intense the color tint is on the killstreak sheen glow for weapons.
 
 !!! warning
-    This module will have no effect if you have `sheens_speed` set to `off`.
+    This module will have no effect if `sheens_speed` is set to `off`.
 
 * **CPU usage:** none
 * **GPU usage:** none


### PR DESCRIPTION
This pull request:

- **fixes `bandwidth=512Kbps` and `bandwidth=762Kbps` not working after the latest release;**
- makes some changes to `contributing.md`;
- removes various random spaces in `comfig.cfg`;
- replaces `net_splitpacket_maxrate`'s comment in `comfig.cfg` to a generic one, since the default rate is 80000 and the current value is not lower than that;
- changes `cl_hud_killstreak_display_alpha` to `120` (its default value) in `comfig.cfg`, like my other pull request;
- adds `hud_contracts=auto` which behaves in the same way as `download=auto`, rather than just leaving it as "unset";
- adds a warning to `sheens_tint` saying it does not work with `sheens_speed=off`;
- changes `config_template.cfg` to not disable HUD achievement tracking by default;
- updates `config_template.cfg` according to changes in `comfig.cfg`.