### PR TITLE
Add sheens_tint=high to the Very Low preset

### DIFF
--- a/config/cfg/presets/very-low.cfg
+++ b/config/cfg/presets/very-low.cfg
@@ -26,6 +26,7 @@ ragdolls=off
 3dsky=off
 jigglebones=off
 sheens_speed=off
+sheens_tint=high
 textures=very_low
 ropes=off
 vsync=off


### PR DESCRIPTION
If one decides to turn on sheens_speed and viewmodels and keep playing with the Very Low preset, one will not have the sheens_tint applied in compliance with the default value. Here's the solution.