### PR TITLE
add information about linux i/o scheduler algorithms

### DIFF
--- a/docs/os/linux.md
+++ b/docs/os/linux.md
@@ -31,6 +31,9 @@ You can install `schedtool` and [Ananicy](https://github.com/Nefelim4ag/Ananicy)
 
 See the [Arch Linux wiki](https://wiki.archlinux.org/index.php/Sysctl#Improving_performance) for information about improving networking parameters for performance.
 
+## I/O Schedulers
+The Linux kernel supports multiple I/O scheduler algorithms for storage devices such as `mq-deadline`, `bfq`, and `kyber`. Depending on the type and speed of your storage device, some of these algorithms may increase or decrase the latency of read requests, as well as overall throughput. See the [Arch Linux wiki](https://wiki.archlinux.org/title/Improving_performance#Input/output_schedulers) for more information.
+
 ## Virtual memory optimization
 
 See the [Arch Linux wiki](https://wiki.archlinux.org/index.php/Sysctl#Virtual_memory) for information about improving virtual memory parameters.


### PR DESCRIPTION
changing the i/o scheduler algorithm for linux can optimize drive read latency, especially on slower hard drives and nvme drives - so i think this might be a good recommendation :)