### PR TITLE
Change default FPS cap to 400

### DIFF
--- a/config/mastercomfig/cfg/comfig/comfig.cfg
+++ b/config/mastercomfig/cfg/comfig/comfig.cfg
@@ -928,7 +928,7 @@ alias fpscap_400"mat_powersavingsmode 0;fps_max 400;alias fpscap_level echo fpsc
 alias fpscap_1000"mat_powersavingsmode 0;fps_max 1000;alias fpscap_level echo fpscap=1000"
 alias fpscap_unlimited"mat_powersavingsmode 0;fps_max 0;alias fpscap_level echo fpscap=unlimited"
 
-alias fpscap fpscap_1000
+alias fpscap fpscap_400
 
 // -------------
 // '-- VSync --'

--- a/data/preset_modules.json
+++ b/data/preset_modules.json
@@ -217,7 +217,7 @@
     "none": ""
   },
   "fpscap": {
-    "default": "1000"
+    "default": "400"
   },
   "vsync": {
     "default": "off",

--- a/docs/customization/modules.md
+++ b/docs/customization/modules.md
@@ -636,7 +636,7 @@ Setting it higher can reduce input delay.
 * **CPU usage:** low
 * **GPU usage:** none
 
-Default setting: **`fpscap=1000`** (all presets).
+Default setting: **`fpscap=400`** (all presets).
 
 * **`fpscap=powersaver`**: Sets FPS cap to half of your display's refresh rate.
 * **`fpscap=30`**: Sets FPS cap to 30 FPS.


### PR DESCRIPTION
From `https://github.com/ValveSoftware/Source-1-Games/issues/4913`:

------------

Like CS:GO, TF2 should have a higher FPS cap to allow monitors with higher refresh rates to benefit from it by default.

CS:GO had a cap of 300, which was raised to 400 a while ago (Valve didn't mention it in any patch notes).

------------

This closes #709.