### PR TITLE
workaround for preloading menu music

### DIFF
--- a/config/mastercomfig/cfg/comfig/comfig.cfg
+++ b/config/mastercomfig/cfg/comfig/comfig.cfg
@@ -105,7 +105,7 @@ alias packet_rate_max"cl_cmdrate 100;cl_updaterate 100;packet_rate_max_aliases;a
 
 alias packet_rate packet_rate_standard
 
-//cl_interp_ratio 1;cl_interp .015 // 1 snapshot interpolation for lowest 
+//cl_interp_ratio 1;cl_interp .015 // 1 snapshot interpolation for lowest
 //cl_interp_ratio 2;cl_interp .03 // 2 snapshots interpolation buffer to avoid issues where one snapshot is dropped once in a while. Safest option for most users.
 //cl_interp_ratio 3;cl_interp .045 // Protect more against packet loss, increase further for more buffer protection. Recommended only for users with an unstable connection.
 //cl_interp 0.1 // Useful for smooth animation, use it in offline recordings and singleplayer
@@ -1076,10 +1076,12 @@ alias match_hud match_hud_on
 
 //map_background itemtest // Map background for enhancing main menu visuals, or to preload content
 
+alias checkpointservercommand "script_execute getpointservercommand; sv_allow_point_servercommand always" // I do not know where to put this.
+
 alias dynamic_background_off"alias dynamic_background_level echo dynamic_background=off"
-alias dynamic_background_preload"map_background preload_room;wait 10;disconnect;alias dynamic_background_level echo dynamic_background=preload"
-alias dynamic_background_itemtest"map_background itemtest;wait 10;disconnect;alias dynamic_background_level echo dynamic_background=itemtest"
-alias dynamic_background_dustbowl"map_background background01;wait 1000;stop;alias dynamic_background_level echo dynamic_background=dustbowl"
+alias dynamic_background_preload"map_background preload_room;wait 5;checkpointservercommand;script_execute randommenumusic;wait 5;disconnect;playmenumusic; alias dynamic_background_level echo dynamic_background=itemtest"
+alias dynamic_background_itemtest"map_background itemtest;wait 5;checkpointservercommand;script_execute randommenumusic;wait 5; disconnect;playmenumusic; alias dynamic_background_level echo dynamic_background=itemtest"
+alias dynamic_background_dustbowl"map_background background01;wait 5;checkpointservercommand;script_execute randommenumusic;wait 995;stop;alias dynamic_background_level echo dynamic_background=dustbowl"
 
 alias dynamic_background dynamic_background_off
 
@@ -1339,7 +1341,7 @@ cc_captiontrace 0 // Do not report missing captions in console
 //net_graphsolid 0 // Draw height ticks as single ticks
 net_graphsolid 1 // Revert back to the Half-Life 1 behavior of drawing a full rectangle
 //net_graphtext 1 // Draw text fields
-//net_graphmsecs 400 // The text area measures over this many milliseconds 
+//net_graphmsecs 400 // The text area measures over this many milliseconds
 //net_graphshowlatency 1 // Show the latency part of the graph
 //net_graphshowinterp 1 // Show the interpolation part of the graph
 

--- a/config/mastercomfig/scripts/vscripts/getpointservercommand.nut
+++ b/config/mastercomfig/scripts/vscripts/getpointservercommand.nut
@@ -1,0 +1,3 @@
+// Due to not being able to use squirrel strings in the console (seems to be a bug?)
+// this needs to be its own file.
+::sPointServerCommandValue <- Convars.GetStr("sv_allow_point_servercommand");

--- a/config/mastercomfig/scripts/vscripts/randommenumusic.nut
+++ b/config/mastercomfig/scripts/vscripts/randommenumusic.nut
@@ -1,0 +1,38 @@
+// This script checks the current ingame holiday, and then randomly picks a main menu song to play
+// This is a workaround to preloading causing music to not play normally.
+
+// we use alias because the sound needs to play after we disconnect, but we can only do RNG while on a listen server.
+// *# before file name tells engine to stream file in and also that it should be affected by the music volume slider
+local sConCommands = "alias playmenumusic play *#ui/";
+
+local iRandomNumber = null;
+
+// Play Halloween music during Scream Fortress
+if ( IsHolidayActive( Constants.EHoliday.kHoliday_Halloween ) )
+{
+    local iRandomNumber = RandomInt(0, 1);
+
+    if (iRandomNumber == 0) {
+        sConCommands += "holiday/gamestartup_halloween.mp3";
+    }
+    else {
+        sConCommands += "holiday/gamestartup_halloween1.mp3";
+    }
+}
+// Play Taps during soldier holiday
+else if ( IsHolidayActive( Constants.EHoliday.kHoliday_Soldier ) ) {
+    sConCommands += "holiday/gamestartup_solider.mp3";
+}
+// Randomly pick from the regular main menu music tracks
+else {
+    // NOTE: the random number generator is unfortunately hardcoded, as there is no way to check if a sound exists
+    // if Valve were to ever add more songs year-round, this file would need to be updated to reflect that.
+    // Get random number between 1 and 29
+    iRandomNumber = RandomInt(1, 29);
+
+    sConCommands += "gamestartup" + iRandomNumber + ".mp3";
+}
+
+SendToServerConsole(sConCommands);
+
+SendToServerConsole("sv_allow_point_servercommand " + sPointServerCommandValue);


### PR DESCRIPTION
New PR targeting release since i was having some trouble just changing the base on #714 

Add some vscript to randomly pick a main menu song and then play it after preloading is finished
This is a kind of crappy workaround for main menu music not playing after preloading, and i think its so bad that right now its just a draft PR.
I have not tested this in the actual VPK as I couldn't figure out how to get the package script to work.
It might honestly be better to just have a semi-random solution only using aliases (just incrementing on every launch), instead of this vscript solution, but that wouldn't be able to check for holidays.

Some notes regarding the implementation of this:
- The wait of 5 ticks before running the script is a semi-random number i picked. At least a few ticks need to take place before vscript is initialized, so the script cannot be run immediately. Due to the fact that vscript isn't initialized immediately, i'm not sure if the amount of ticks needed to wait might vary depending on PC specs.
- In theory, getpointservercommand.nut could be condensed down into just a single line in the `checkpointservercommand` alias instead of its own file, but due to quirks of how vscript and the console interact, I could not get it to work. VDC claims that backticks work in place of quotes, but it just caused errors if i could even get it into the console
- I have no clue if `checkpointservercommand` is in a good place or not, I just placed it there as a guess.
- The fact that this has to use sv_allow_point_servercommand makes me uneasy, even if its setup to set it back to the value it was at prior to being set to "always" as soon as possible. vscript does have a `SendToConsole` function for clients which _doesn't_ require this command but it didn't seem to work unless i was fully loaded in and had selected a team.
- There is no way currently to disable the main menu music. Normally you can use the launch option `-nostartupsound`, but there's no way to check launch options via vscript. Maybe worth adding an on/off module for it? would probably ONLY work with this workaround, unless we want to run snd_restart on every launch for some reason.
- I'm not sure if scream fortress music plays on full moons (i don't think so?) if it does, `Constants.EHoliday.kHoliday_Halloween` can be changed to `Constants.EHoliday.kHoliday_HalloweenAndFullMoon`
- There's a song in the files for Saxxy's, but there is no "holiday" for it, so i don't think its possible to check for, should Valve decide to host another one.
- If Valve were to add new songs to the game for any reason, this script would have to be updated, due to not being able to check what files exist. Maybe an external script could check the files for `gamestartup*.mp3` on game update and then update the .nut files accordingly?
- I have no clue if this will work with the current package script, nor do I know how to change it to make it work if it doesn't.
- The .nut files should be all setup to work with the `shrink_key_values.sh` script, but i have not tested it
- The names for the aliases and script files are just awful.

Also, my text editor appears to have removed 2 instances of whitespace in comfig.cfg, cool