### PR TITLE
Fix issues with main menu music script

### DIFF
--- a/config/mastercomfig/cfg/comfig/comfig.cfg
+++ b/config/mastercomfig/cfg/comfig/comfig.cfg
@@ -1043,12 +1043,12 @@ alias match_hud match_hud_on
 
 //map_background itemtest // Map background for enhancing main menu visuals, or to preload content
 
-alias checkpointservercommand "script_execute getpointservercommand; sv_allow_point_servercommand always" // I do not know where to put this.
+alias checkpointservercommand "script_execute getpointservercommand; sv_allow_point_servercommand always" // Store previous sv_allow_point_servercommand value and then set to "always", for usage with the main menu music script.
 
 alias dynamic_background_off"alias dynamic_background_level echo dynamic_background=off"
-alias dynamic_background_preload"map_background preload_room;wait 5;checkpointservercommand;script_execute randommenumusic;wait 5;disconnect;playmenumusic; alias dynamic_background_level echo dynamic_background=itemtest"
-alias dynamic_background_itemtest"map_background itemtest;wait 5;checkpointservercommand;script_execute randommenumusic;wait 5; disconnect;playmenumusic; alias dynamic_background_level echo dynamic_background=itemtest"
-alias dynamic_background_dustbowl"map_background background01;wait 5;checkpointservercommand;script_execute randommenumusic;wait 995;stop;alias dynamic_background_level echo dynamic_background=dustbowl"
+alias dynamic_background_preload"map_background preload_room;wait 5;checkpointservercommand;script_execute randommenumusic;wait 5;disconnect;playmenumusic;alias dynamic_background_level echo dynamic_background=preload"
+alias dynamic_background_itemtest"map_background itemtest;wait 5;checkpointservercommand;script_execute randommenumusic;wait 5; disconnect;playmenumusic;alias dynamic_background_level echo dynamic_background=itemtest"
+alias dynamic_background_dustbowl"map_background background01;wait 5;checkpointservercommand;script_execute randommenumusic;wait 995;stop;playmenumusic;alias dynamic_background_level echo dynamic_background=dustbowl"
 
 alias dynamic_background dynamic_background_off
 

--- a/config/mastercomfig/scripts/vscripts/randommenumusic.nut
+++ b/config/mastercomfig/scripts/vscripts/randommenumusic.nut
@@ -21,7 +21,7 @@ if ( IsHolidayActive( Constants.EHoliday.kHoliday_Halloween ) )
 }
 // Play Taps during soldier holiday
 else if ( IsHolidayActive( Constants.EHoliday.kHoliday_Soldier ) ) {
-    sConCommands += "holiday/gamestartup_solider.mp3";
+    sConCommands += "holiday/gamestartup_soldier.mp3";
 }
 // Randomly pick from the regular main menu music tracks
 else {

--- a/dev/common.sh
+++ b/dev/common.sh
@@ -2,17 +2,17 @@
 function cleanItems {
   if [ "${zip_package:=false}" != true ] ; then
     # remove comments, including indented comments
-    find . \( -name "*.cfg" -o -name "*.txt" -o -name "*.res" \) -print0 | xargs -0 sed -i '/^[[:blank:]]*\/\//d;s/\/\/.*//'
+    find . \( -name "*.cfg" -o -name "*.txt" -o -name "*.res" -o -name "*.nut" \) -print0 | xargs -0 sed -i '/^[[:blank:]]*\/\//d;s/\/\/.*//'
     # remove leading and trailing whitespace
-    find . \( -name "*.cfg" -o -name "*.txt" -o -name "*.res"  \) -print0  | xargs -0 sed -i 's/^[[:blank:]]*//;s/[[:blank:]]*$//'
+    find . \( -name "*.cfg" -o -name "*.txt" -o -name "*.res" -o -name "*.nut" \) -print0  | xargs -0 sed -i 's/^[[:blank:]]*//;s/[[:blank:]]*$//'
     # remove blank lines
-    find . \( -name "*.cfg" -o -name "*.txt" -o -name "*.res" \) -print0 | xargs -0 sed -i '/^\s*$/d'
+    find . \( -name "*.cfg" -o -name "*.txt" -o -name "*.res" -o -name "*.nut" \) -print0 | xargs -0 sed -i '/^\s*$/d'
     # remove quotes from VDF key values TODO: don't remove empty quotes or spaced strings
     find . \( -name "mtp.cfg" -o -name "dxsupport*.cfg" \
      -o -name "*.txt" -and ! -name "texture_preload_list.txt" -o -name "*.res" \) -print0 | xargs -0 -I{} ../shrink_key_values.sh {}
     # Remove newlines from VDF key values
     find . \( -name "mtp.cfg" -o -name "dxsupport*.cfg" \
-     -o -name "*.txt" -and ! -name "texture_preload_list.txt" -o -name "*.res" \) -print0 | xargs -0 sed -i -z 's/\n/ /g'
+     -o -name "*.txt" -and ! -name "texture_preload_list.txt" -o -name "*.res" -o -name "*.nut" \) -print0 | xargs -0 sed -i -z 's/\n/ /g'
     # remove extraneous whitespace from VDF key values
     find . \( -name "mtp.cfg" -o -name "dxsupport*.cfg" \
      -o -name "*.txt" -o -name "*.res" \) -print0 | xargs -0 sed -i -e "s/[[:space:]]\+/ /g"


### PR DESCRIPTION
Should've noticed these issues before, but I only double checked the PR after it was merged.

-Changed comment in comfig.cfg to actually say what it does
-Fixed dynamic_background=dustbowl to play music (Although after testing it, it is a bit weird hearing music and the soundscapes of background01. Up to taste, maybe worth having a "no music" option?)
-Fixed dynamic_background=preload setting `dynamic_background_level` to `echo dynamic_background=itemtest`
-Fixed typo causing Taps to not play during Soldier holiday
-Added .nut files to the cleanItems function in dev/common.sh to reduce filesize. I have 0 experience with this so I just added these to the pre-existing cleaning functions. It DOES NOT clean whitespace! also there's some places in the file that need a bit of whitespace, so a naive script won't work.