### PR TITLE
Change license and security files

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2016-2024 mastercoms
+Copyright (c) 2016 mastercoms
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,13 +1,9 @@
-# Security Policy
+# Security policy
 
-## Supported Versions
+## Supported versions
+Only the [latest version](https://github.com/mastercomfig/mastercomfig/releases/latest) is supported.
 
-| Version   | Supported          |
-| --------- | ------------------ |
-| 9.10.x     | :white_check_mark: |
-| < 9.10.x   | :x:                |
-
-## Reporting a Vulnerability
+## Reporting a vulnerability
 
 If you find a security vulnerability in the mastercomfig app, execution of mastercomfig,
 or something else, contact mastercoms through email directly: [support@mastercomfig.com](mailto:support@mastercomfig.com).


### PR DESCRIPTION
- Change license file to only state the initial year of the comfig. No need to change the year every year, because only the initial year is actually relevant.
- Change security file to state that only the latest version is supported. It avoids commits to keep changing the comfig version, and it also only makes sense to support the latest version given the scope of the project.