### PR TITLE
Minor clean-ups

### DIFF
--- a/config/mastercomfig/cfg/comfig/comfig.cfg
+++ b/config/mastercomfig/cfg/comfig/comfig.cfg
@@ -672,18 +672,17 @@ alias gibs
 // -------------
 // Various small objects
 
-//r_decalstaticprops 1 // Use proper ambient lighting data for static props, enable decals on static props
-//r_decalstaticprops 0 // Do not use some lighting data for static props, disable decals on static props
-//cl_phys_props_enable 1 // Enable client side physics props
-//cl_phys_props_enable 0 // Disable client side physics props
+//r_decalstaticprops 1 // Use proper ambient lighting data for static props. Enables decals on static props.
+//r_decalstaticprops 0 // Do not use some lighting data for static props. Disables decals on static props.
+//cl_phys_props_enable 0 // Disable client-side physics props
 //cl_phys_props_max 300 // Allow all physics props
 //cl_phys_props_max 20 // Reduce the physics props limit to a reasonable one for TF2
 //cl_phys_props_respawndist 1500 // Do not spawn props if we can see them
 //cl_phys_props_respawndist 3000 // Skip respawning physics props for a high distance
 //cl_phys_props_respawnrate 60 // Respawn physics props faster
 //cl_phys_props_respawnrate 120 // Respawn physics props at a slower rate
-//r_propsmaxdist 900 // Maximum distance from where client side physics props are visible
-//r_propsmaxdist 3000 // Always render client side physics props
+//r_propsmaxdist 900 // Maximum distance from where client-side physics props are visible
+//r_propsmaxdist 3000 // Always render client-side physics props
 //r_drawdetailprops 1 // Enable sprites, grass and some other things
 //r_drawdetailprops 0 // Disable detail props for saving a good bit of FPS
 //r_staticprop_lod 7 // Force lowest LOD (lowest quality). Makes some railings invisible.
@@ -1405,7 +1404,7 @@ alias outlines
 //tf_replay_pyrovision 0 // Do not force Pyrovision in replays
 //tf_replay_pyrovision 1 // Watch replays in Pyrovision
 //replay_rendersetting_motionblur_can_toggle 1 // Allow for motion blur toggle in replays
-//replay_cache_client_ragdolls 1 // Record client side ragdolls
+//replay_cache_client_ragdolls 1 // Record client-side ragdolls
 //replay_voice_during_playback 1 // Play voice chat during replay playback
 //replay_screenshotresolution 1 // High-resolution replay screenshots (use 0 for low-resolution)
 

--- a/config/mastercomfig/cfg/comfig/legacy/opengl.cfg
+++ b/config/mastercomfig/cfg/comfig/legacy/opengl.cfg
@@ -2,7 +2,7 @@ mat_bufferprimitives 0 // OpenGL must flush out primitives
 gl_pow2_tempmem 1 // Use better texture storage for better memory usage/fragmentation
 gl_mtglflush_at_tof 1 // Use glFlush instead of ForceHardwareSync
 mat_forcehardwaresync 0 // ^
-gl_debug_output 0 // Disable debug output
+//gl_debug_output 0 // Disable debug output
 gl_magnify_resolve_mode 1 // Fastest upscale mode, instead of nicest
 gl_batch_tex_creates 1 // Use a reserved list of gl textures to batch
 gl_batch_tex_destroys 1 // ^

--- a/config/templates/config/config_template.cfg
+++ b/config/templates/config/config_template.cfg
@@ -436,18 +436,17 @@ tf_playergib 0 // Control gibbing on local servers: 0: never, 1: default, 2: alw
 // -------------
 // Various small objects
 
-//r_decalstaticprops 1 // Use proper ambient lighting data for static props, enable decals on static props
-r_decalstaticprops 0 // Do not use some lighting data for static props, disable decals on static props
-//cl_phys_props_enable 1 // Enable client side physics props
-cl_phys_props_enable 0 // Disable client side physics props
+//r_decalstaticprops 1 // Use proper ambient lighting data for static props. Enables decals on static props.
+r_decalstaticprops 0 // Do not use some lighting data for static props. Disables decals on static props.
+cl_phys_props_enable 0 // Disable client-side physics props
 //cl_phys_props_max 300 // Allow all physics props
 //cl_phys_props_max 20 // Reduce the physics props limit to a reasonable one for TF2
 //cl_phys_props_respawndist 1500 // Do not spawn props if we can see them
 //cl_phys_props_respawndist 3000 // Skip respawning physics props for a high distance
 //cl_phys_props_respawnrate 60 // Respawn physics props faster
 //cl_phys_props_respawnrate 120 // Respawn physics props at a slower rate
-r_propsmaxdist 0 // Maximum distance from where client side physics props are visible
-//r_propsmaxdist 3000 // Always render client side physics props
+r_propsmaxdist 0 // Maximum distance from where client-side physics props are visible
+//r_propsmaxdist 3000 // Always render client-side physics props
 //r_drawdetailprops 1 // Enable sprites, grass and some other things
 r_drawdetailprops 0 // Disable detail props for saving a good bit of FPS
 //r_staticprop_lod 7 // Force lowest LOD (lowest quality). Makes some railings invisible.
@@ -984,7 +983,7 @@ replay_rendersetting_renderglow 0 // Disable glows in replays and demos
 //tf_replay_pyrovision 0 // Do not force Pyrovision in replays
 //tf_replay_pyrovision 1 // Watch replays in Pyrovision
 //replay_rendersetting_motionblur_can_toggle 1 // Allow for motion blur toggle in replays
-//replay_cache_client_ragdolls 1 // Record client side ragdolls
+//replay_cache_client_ragdolls 1 // Record client-side ragdolls
 //replay_voice_during_playback 1 // Play voice chat during replay playback
 //replay_screenshotresolution 1 // High-resolution replay screenshots (use 0 for low-resolution)
 

--- a/docs/customization/modules.md
+++ b/docs/customization/modules.md
@@ -460,10 +460,10 @@ Controls the rendering of various small objects.
 
 Default setting: based on which preset you are currently using.
 
-- **`props=low`**: Disables client side props like bottles, disables foliage, low quality prop models and invisible railings.
-- **`props=medium`**: Disables client side props, disables foliage, default quality prop models.
-- **`props=high`**: Enables ambient lighting and decals on static props, enables a small number of client side props, enables foliage at a reasonable distance with instant pop in, default quality prop models.
-- **`props=ultra`** Enables ambient lighting and decals on static props, enables a high number of client side props, enables foliage at practically any distance, max quality prop models regardless of distance.
+- **`props=low`**: Disables client-side props like bottles, disables foliage, low quality prop models and invisible railings.
+- **`props=medium`**: Disables client-side props, disables foliage, default quality prop models.
+- **`props=high`**: Enables ambient lighting and decals on static props, enables a small number of client-side props, enables foliage at a reasonable distance with instant pop in, default quality prop models.
+- **`props=ultra`** Enables ambient lighting and decals on static props, enables a high number of client-side props, enables foliage at practically any distance, max quality prop models regardless of distance.
 
 ### Ragdolls
 


### PR DESCRIPTION
- Adds hyphen to text instances of "client side" (except those auto-generated by the game such as cvarlists).
- Do not set `gl_debug_output 0` anymore in accordance to <https://github.com/mastercomfig/mastercomfig/commit/0aa4149ae8c8d6b8dce8daf87132582b3cb66818#diff-966db877dc7e342074c61d3acfd3d1f5e4e16bedaff5fd0a76d354cdcc6627e0R161-R162>.
- Minor comment changes to `r_decalstaticprops`.
- Removed useless `cl_phys_props_enable` distinction.