### PR TITLE
mm_override.cfg changes

### DIFF
--- a/config/mastercomfig/cfg/comfig/mm_override.cfg
+++ b/config/mastercomfig/cfg/comfig/mm_override.cfg
@@ -17,14 +17,15 @@ mat_alphacoverage 1
 mat_bumpmap 1
 mat_disable_fancy_blending 0
 mat_disable_lightwarp 0
+mat_filterlightmaps 1
 mat_filtertextures 1
 mat_phong 1
 mat_reducefillrate 0
 mat_reduceparticles 0
 mat_specular 1
-mat_supportflashlight 0
 mp_decals 200
 nb_shadow_dist 400
+props_break_max_pieces -1
 r_3dsky 1
 r_WaterDrawReflection 1
 r_WaterDrawRefraction 1
@@ -55,7 +56,6 @@ r_staticprop_lod -1
 r_teeth 1
 r_worldlightmin 0.0002
 r_worldlights 4
-ragdoll_sleepaftertime 5.0f
 
 echo"Cleaned up mastercomfig settings for use in Competitive Matchmaking"
 echo"Competitive settings will persist until the game is restarted"


### PR DESCRIPTION
Added `mat_filterlightmaps` and `props_break_max_pieces`.

Removed `mat_supportflashlight` (the game automatically determines the ideal value if necessary) and a ragdoll-related ConVar since we don't have the others (cl_ragdoll etc.).