### PR TITLE
Fix invalid tracers module level

### DIFF
--- a/data/preset_modules.json
+++ b/data/preset_modules.json
@@ -66,7 +66,7 @@
     "default": "low",
     "medium": "medium",
     "high": "high",
-    "ultra": "ultra"
+    "ultra": "high"
   },
   "water": {
     "destitute": "very_low",


### PR DESCRIPTION
Ultra uses `high` rather than `ultra` level (`ultra` level does not exist).

Only the app is affected.