### PR TITLE
Make comfig echo be executed later

### DIFF
--- a/config/mastercomfig/cfg/comfig/finalize.cfg
+++ b/config/mastercomfig/cfg/comfig/finalize.cfg
@@ -1,4 +1,5 @@
 // Runs after user override configs and addons
 mat_savechanges // Make sure we init next time with our material system ConVars to prevent reloads
 //playdemo ?. // Pre-init loading screen with less elements for faster load time
+exec comfig/echo.cfg // Run mastercomfig echo
 dynamic_background // Run dynamic_background after everything

--- a/dev/presets/package.sh
+++ b/dev/presets/package.sh
@@ -18,7 +18,6 @@ autoexec_file=mastercomfig-base/cfg/autoexec.cfg
   printf "preset;"
   printf "modules_c;"
   printf "run_modules;"
-  printf "exec comfig/echo.cfg;"
   printf "exec app/addons.cfg;"
   printf "exec overrides/autoexec.cfg;exec app/autoexec.cfg;"
   printf "exec comfig/finalize.cfg"


### PR DESCRIPTION
"Hides" ugly messages such as "app/addons.cfg not present; not executing" appearing after the echo.

Runs after all commands, except dynamic_background module.