### PR TITLE
Consolidate load order between app and overrides

### DIFF
--- a/config/mastercomfig/cfg/comfig/comfig.cfg
+++ b/config/mastercomfig/cfg/comfig/comfig.cfg
@@ -1981,7 +1981,7 @@ alias modules_c"exec overrides/modules.cfg"
 
 alias run_modules"exec comfig/modules_run.cfg"
 alias module_levels"exec comfig/module_levels.cfg"
-alias apply_overrides"modules_c;run_modules;exec overrides/autoexec.cfg;exec app/autoexec.cfg"
+alias apply_overrides"modules_c;run_modules;exec app/autoexec.cfg;exec overrides/autoexec.cfg"
 alias restore_preset"exec comfig/comfig.cfg;preset;run_modules"
 alias restore_config"exec autoexec.cfg"
 

--- a/config/mastercomfig/cfg/comfig/comfig.cfg
+++ b/config/mastercomfig/cfg/comfig/comfig.cfg
@@ -1966,7 +1966,7 @@ alias class_config_medic"exec overrides/medic.cfg"
 alias class_config_sniper"exec overrides/sniper.cfg"
 alias class_config_spy"exec overrides/spy.cfg"
 
-alias game_overrides_c"exec overrides/game_overrides.cfg"
+alias game_overrides_c"exec app/game_overrides.cfg;exec overrides/game_overrides.cfg"
 alias game_overrides_once_c
 
 // ----------------------------

--- a/config/mastercomfig/cfg/comfig/comfig.cfg
+++ b/config/mastercomfig/cfg/comfig/comfig.cfg
@@ -1956,15 +1956,15 @@ alias logo=on"alias logo logo_on"
 // '-- User-Overrideable Aliases --'
 // ---------------------------------
 
-alias class_config_scout"exec overrides/scout.cfg"
-alias class_config_soldier"exec overrides/soldier.cfg"
-alias class_config_pyro"exec overrides/pyro.cfg"
-alias class_config_demoman"exec overrides/demoman.cfg"
-alias class_config_heavyweapons"exec overrides/heavyweapons.cfg"
-alias class_config_engineer"exec overrides/engineer.cfg"
-alias class_config_medic"exec overrides/medic.cfg"
-alias class_config_sniper"exec overrides/sniper.cfg"
-alias class_config_spy"exec overrides/spy.cfg"
+alias class_config_scout"exec app/scout.cfg;exec overrides/scout.cfg"
+alias class_config_soldier"exec app/soldier.cfg;exec overrides/soldier.cfg"
+alias class_config_pyro"exec app/pyro.cfg;exec overrides/pyro.cfg"
+alias class_config_demoman"exec app/demoman.cfg;exec overrides/demoman.cfg"
+alias class_config_heavyweapons"exec app/heavyweapons.cfg;exec overrides/heavyweapons.cfg"
+alias class_config_engineer"exec app/engineer.cfg;exec overrides/engineer.cfg"
+alias class_config_medic"exec app/medic.cfg;exec overrides/medic.cfg"
+alias class_config_sniper"exec app/sniper.cfg;exec overrides/sniper.cfg"
+alias class_config_spy"exec app/spy.cfg;exec overrides/spy.cfg"
 
 alias game_overrides_c"exec app/game_overrides.cfg;exec overrides/game_overrides.cfg"
 alias game_overrides_once_c

--- a/config/mastercomfig/cfg/comfig/game_overrides.cfg
+++ b/config/mastercomfig/cfg/comfig/game_overrides.cfg
@@ -11,5 +11,4 @@ alias block_game_overrides_once"alias game_overrides_once;match_hud_alias2";bloc
 
 // Game overrides
 game_overrides // Run aliased game overrides
-game_overrides_c // Run custom aliased game overrides
-exec app/game_overrides.cfg // Run app game overrides
+game_overrides_c // Run app and custom aliased game overrides

--- a/config/mastercomfig/cfg/demoman.cfg
+++ b/config/mastercomfig/cfg/demoman.cfg
@@ -6,5 +6,3 @@ net_projectiles;snapshot_buffer
 run_game_overrides // Override values set every game
 
 class_config_demoman
-
-exec app/demoman.cfg

--- a/config/mastercomfig/cfg/engineer.cfg
+++ b/config/mastercomfig/cfg/engineer.cfg
@@ -9,5 +9,3 @@ net_hitscan;snapshot_buffer
 run_game_overrides // Override values set every game
 
 class_config_engineer
-
-exec app/engineer.cfg

--- a/config/mastercomfig/cfg/heavyweapons.cfg
+++ b/config/mastercomfig/cfg/heavyweapons.cfg
@@ -4,5 +4,3 @@ net_hitscan;snapshot_buffer
 run_game_overrides // Override values set every game
 
 class_config_heavyweapons
-
-exec app/heavyweapons.cfg

--- a/config/mastercomfig/cfg/medic.cfg
+++ b/config/mastercomfig/cfg/medic.cfg
@@ -7,5 +7,3 @@ net_projectiles;snapshot_buffer
 run_game_overrides // Override values set every game
 
 class_config_medic
-
-exec app/medic.cfg

--- a/config/mastercomfig/cfg/pyro.cfg
+++ b/config/mastercomfig/cfg/pyro.cfg
@@ -6,5 +6,3 @@ net_projectiles;snapshot_buffer
 run_game_overrides // Override values set every game
 
 class_config_pyro
-
-exec app/pyro.cfg

--- a/config/mastercomfig/cfg/scout.cfg
+++ b/config/mastercomfig/cfg/scout.cfg
@@ -6,5 +6,3 @@ net_hitscan;snapshot_buffer
 run_game_overrides // Override values set every game
 
 class_config_scout
-
-exec app/scout.cfg

--- a/config/mastercomfig/cfg/sniper.cfg
+++ b/config/mastercomfig/cfg/sniper.cfg
@@ -6,5 +6,3 @@ net_hitscan;snapshot_buffer
 run_game_overrides // Override values set every game
 
 class_config_sniper
-
-exec app/sniper.cfg

--- a/config/mastercomfig/cfg/soldier.cfg
+++ b/config/mastercomfig/cfg/soldier.cfg
@@ -6,5 +6,3 @@ net_projectiles;snapshot_buffer
 run_game_overrides // Override values set every game
 
 class_config_soldier
-
-exec app/soldier.cfg

--- a/config/mastercomfig/cfg/spy.cfg
+++ b/config/mastercomfig/cfg/spy.cfg
@@ -5,5 +5,3 @@ net_spy;snapshot_buffer
 run_game_overrides // Override values set every game
 
 class_config_spy
-
-exec app/spy.cfg

--- a/dev/presets/package.sh
+++ b/dev/presets/package.sh
@@ -20,7 +20,7 @@ autoexec_file=mastercomfig-base/cfg/autoexec.cfg
   printf "run_modules;"
   printf "exec comfig/echo.cfg;"
   printf "exec app/addons.cfg;"
-  printf "exec overrides/autoexec.cfg;exec app/autoexec.cfg;"
+  printf "exec app/autoexec.cfg;exec overrides/autoexec.cfg;"
   printf "exec comfig/finalize.cfg"
 } > "${autoexec_file}"
 


### PR DESCRIPTION
Looking through the files, I noticed that some scripts in the `app` directory are executed after those in the `overrides` directory. If I'm not mistaken, the intended behaviour is to always run scripts from the former before the latter.

This pull request modifies the scripts I identified to match the description of the [9.100.0](https://github.com/mastercomfig/mastercomfig/releases/tag/9.100.0) patch notes.

> - Your own files remain in cfg/overrides/, but the app will generate an cfg/app/ folder for itself to generate its own files without replacing your files

I will be watching for any changes you request in case you want to merge this.