### PR TITLE
docs: Remove TF2 Bot Detector from "See Also"

### DIFF
--- a/docs/customization/see_also.md
+++ b/docs/customization/see_also.md
@@ -92,9 +92,6 @@ Wanting to get more out of TF2? Look no further for a comprehensive list of comm
 * [Steam Priority Launcher](https://github.com/Leo40Git/SteamPriorityLauncher)
   — A launcher for launching Steam games, such as TF2, with different priorities
 
-* [TF2 Bot Detector](https://github.com/PazerOP/tf2_bot_detector)
-  — Automatically detects and votekicks cheaters/bots in TF2 casual
-
 * [Vote HUD Custom Font](https://github.com/andy013/votehud_custom_font)
   — Uses a custom font on the Vote HUD to show the invisible characters that bots use in their name
 


### PR DESCRIPTION
- PazerOP's original software has been archived for more than two years.
- The only active fork of PazerOP's software is vibecoded.
- botdetector.tf, owned by PazerOP, redirects to https://github.com/leighmacdonald/bd , which seems to be abandoned.

See also: https://github.com/mastercomfig/mastercomfig/pull/831